### PR TITLE
Unathi sprite fixes, part 1

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -22,8 +22,8 @@
 /datum/species/unathi
 	name = SPECIES_UNATHI
 	name_plural = "Unathi"
-	icobase = 'icons/mob/human_races/r_lizard.dmi'
-	deform = 'icons/mob/human_races/r_def_lizard.dmi'
+	icobase = 'icons/mob/human_races/r_lizard_vr.dmi'		//Eclipse edit.
+	deform = 'icons/mob/human_races/r_def_lizard_vr.dmi'		//Eclipse edit.
 	tail = "sogtail"
 	tail_animation = 'icons/mob/species/unathi/unathi_tail.dmi'
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -25,7 +25,7 @@
 	icobase = 'icons/mob/human_races/r_lizard_vr.dmi'		//Eclipse edit.
 	deform = 'icons/mob/human_races/r_def_lizard_vr.dmi'		//Eclipse edit.
 	tail = "sogtail"
-	tail_animation = 'icons/mob/species/unathi/unathi_tail.dmi'
+	tail_animation = 'icons/mob/species/unathi/tail_vr.dmi'		//Eclipse edit.
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	primitive_form = SPECIES_MONKEY_UNATHI
 	darksight = 3

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1123,7 +1123,7 @@ var/global/list/damage_icon_parts = list()
 
 	if(update_icons) update_icons()
 
-// // // BEGIN ECLIPSE EDITS // // //
+
 /mob/living/carbon/human/proc/update_tail_showing(var/update_icons=1)
 	overlays_standing[TAIL_LAYER] = null
 
@@ -1137,14 +1137,11 @@ var/global/list/damage_icon_parts = list()
 
 	if(species_tail && !(wear_suit && wear_suit.flags_inv & HIDETAIL))
 		var/icon/tail_s = get_tail_icon()
-		tail_s.layer = (-100)+TAIL_LAYER
 		overlays_standing[TAIL_LAYER] = image(tail_s, icon_state = "[species_tail]_s")
 		animate_tail_reset(0)
 
 	if(update_icons)
 		update_icons()
-
-// // // END ECLIPSE EDITS // // //
 
 /mob/living/carbon/human/proc/get_tail_icon()
 	var/icon_key = "[species.race_key][r_skin][g_skin][b_skin]"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1137,6 +1137,7 @@ var/global/list/damage_icon_parts = list()
 
 	if(species_tail && !(wear_suit && wear_suit.flags_inv & HIDETAIL))
 		var/icon/tail_s = get_tail_icon()
+		tail_s.layer = (-100)+TAIL_LAYER
 		overlays_standing[TAIL_LAYER] = image(tail_s, icon_state = "[species_tail]_s")
 		animate_tail_reset(0)
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -1123,7 +1123,7 @@ var/global/list/damage_icon_parts = list()
 
 	if(update_icons) update_icons()
 
-
+// // // BEGIN ECLIPSE EDITS // // //
 /mob/living/carbon/human/proc/update_tail_showing(var/update_icons=1)
 	overlays_standing[TAIL_LAYER] = null
 
@@ -1143,6 +1143,8 @@ var/global/list/damage_icon_parts = list()
 
 	if(update_icons)
 		update_icons()
+
+// // // END ECLIPSE EDITS // // //
 
 /mob/living/carbon/human/proc/get_tail_icon()
 	var/icon_key = "[species.race_key][r_skin][g_skin][b_skin]"


### PR DESCRIPTION
* Fixes Unathi sprites using wrong sprite files.

I did what I could to try to pin down the layering issue. The species' stock tail is on the correct layer, but the custom tails are not. I don't know why this is, and I've hit a brick wall tracking it down.
