### PR TITLE
Adds a "Copy Slot" button to the character menu, as requested in #32

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -333,7 +333,7 @@
 		dat += "<b>Once selected, you need to SAVE to confirm</b><hr>"
 		var/name
 		for(var/i=1, i<= config.character_slots, i++)
-			S.cd = "/character[i]"
+			S.cd = GLOB.maps_data.character_load_path(S, i)
 			S["real_name"] >> name
 			if(!name)	name = "Character[i]"
 			if(i==default_slot)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -96,7 +96,8 @@
 		dat += "<a href='?src=\ref[src];load=1'>Load slot</a> - "
 		dat += "<a href='?src=\ref[src];save=1'>Save slot</a> - "
 		dat += "<a href='?src=\ref[src];resetslot=1'>Reset slot</a> - "
-		dat += "<a href='?src=\ref[src];reload=1'>Reload slot</a>"
+		dat += "<a href='?src=\ref[src];reload=1'>Reload slot</a> - "		//Eclipse edit.
+		dat += "<a href='?src=\ref[src];copy=1'>Copy slot</a> "				//Eclipse edit.
 
 	else
 		dat += "Please create an account to save your preferences."
@@ -157,6 +158,14 @@
 			return FALSE
 		load_character(SAVE_RESET)
 		sanitize_preferences()
+	else if(href_list["copy"])			//Eclipse edit.
+		if(!IsGuestKey(usr.key))
+			open_copy_dialog(usr)
+			return 1
+	else if(href_list["overwrite"])		//Eclipse edit.
+		overwrite_character(text2num(href_list["overwrite"]))
+		sanitize_preferences()
+		close_load_dialog(usr)
 	else
 		return 0
 
@@ -313,3 +322,26 @@
 		panel.close()
 		panel = null
 	user << browse(null, "window=saves")
+
+/datum/preferences/proc/open_copy_dialog(mob/user)		//Eclipse edit.
+	var/dat = "<body>"
+	dat += "<tt><center>"
+
+	var/savefile/S = new /savefile(path)
+	if(S)
+		dat += "<b>Select a character slot to overwrite</b><br>"
+		dat += "<b>Once selected, you need to SAVE to confirm</b><hr>"
+		var/name
+		for(var/i=1, i<= config.character_slots, i++)
+			S.cd = "/character[i]"
+			S["real_name"] >> name
+			if(!name)	name = "Character[i]"
+			if(i==default_slot)
+				name = "<b>[name]</b>"
+			dat += "<a href='?src=\ref[src];overwrite=[i]'>[name]</a><br>"
+
+	dat += "<hr>"
+	dat += "</center></tt>"
+	panel = new(user, "Character Slots", "Character Slots", 300, 390, src)
+	panel.set_content(dat)
+	panel.open()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -85,7 +85,7 @@
 	loaded_character = S
 	return S
 
-/datum/preferences/proc/overwrite_character(slot)		//Eclipse edit.
+/datum/preferences/proc/overwrite_character(slot)			//Eclipse edit.
 	if(!path)				return 0
 	if(!fexists(path))		return 0
 	var/savefile/S = new /savefile(path)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -85,6 +85,23 @@
 	loaded_character = S
 	return S
 
+/datum/preferences/proc/overwrite_character(slot)		//Eclipse edit.
+	if(!path)				return 0
+	if(!fexists(path))		return 0
+	var/savefile/S = new /savefile(path)
+	if(!S)					return 0
+	if(!slot)	slot = default_slot
+	if(slot != SAVE_RESET)
+		slot = sanitize_integer(slot, 1, config.character_slots, initial(default_slot))
+		if(slot != default_slot)
+			default_slot = slot
+			S["default_slot"] << slot
+
+	else
+		S["default_slot"] << default_slot
+
+	return 1
+
 /datum/preferences/proc/sanitize_preferences()
 	player_setup.sanitize_setup()
 	return 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It adds a Copy Slot button on the character creator menu. The button opens up a dialogue box asking for the user to select a profile to overwrite with their currently selected character. Once selected, the user then has to click Save Slot to save that same character to the new slot. 

The dialogue box shows the names of the currently saved characters in order to avoid accidental overwriting of an existing saved character.

Closes #32 

## Why It's Good For The Game
You can quickly and easily make multiple copies of the same character for minor changes.

## Changelog
:cl:
add: Added a "Copy Slot" button in the character creator menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
