### PR TITLE
Fixed zippo lighter sprite!

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -444,6 +444,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/weapon/flame/lighter/zippo
 	name = "\improper Zippo lighter"
 	desc = "The zippo."
+	icon = 'icons/obj/zippo.dmi'
 	icon_state = "zippo"
 	item_state = "zippo"
 
@@ -459,8 +460,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(user.r_hand == src || user.l_hand == src)
 		if(!lit)
 			lit = 1
-			icon_state = "[base_state]-on"
-			item_state = "[base_state]-on"
+			icon = 'icons/obj/zippo.dmi'
+			icon_state = "[base_state]on"
+			item_state = "[base_state]on"
 			if(istype(src, /obj/item/weapon/flame/lighter/zippo) )
 				playsound(src, 'sound/items/zippo.ogg', 20, 1, 1)
 				user.visible_message("<span class='rose'>Without even breaking stride, [user] flips open and lights [src] in one smooth movement.</span>")

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -444,7 +444,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/weapon/flame/lighter/zippo
 	name = "\improper Zippo lighter"
 	desc = "The zippo."
-	icon = 'icons/obj/zippo.dmi'
+	icon = 'icons/obj/zippo.dmi'		//Eclipse edit
 	icon_state = "zippo"
 	item_state = "zippo"
 
@@ -461,8 +461,8 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		if(!lit)
 			lit = 1
 			icon = 'icons/obj/zippo.dmi'
-			icon_state = "[base_state]on"
-			item_state = "[base_state]on"
+			icon_state = "[base_state]on"		//Eclipse edit
+			item_state = "[base_state]on"		//Eclipse edit
 			if(istype(src, /obj/item/weapon/flame/lighter/zippo) )
 				playsound(src, 'sound/items/zippo.ogg', 20, 1, 1)
 				user.visible_message("<span class='rose'>Without even breaking stride, [user] flips open and lights [src] in one smooth movement.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the zippo sprite not displaying when turned on. Closes #236 
![image](https://user-images.githubusercontent.com/45645502/86389706-08168a80-bc97-11ea-96ca-1f551efa5961.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It fixes a missing sprite.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed zippo lighter sprite not displaying when flicked open.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
