### PR TITLE
Fixed paper bin sprites and messages.

### DIFF
--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -73,7 +73,6 @@
 
 	add_fingerprint(user)
 	return
-	.=..()
 
 //Pickup paperbins with drag n drop
 obj/item/weapon/paper_bin/MouseDrop(over_object)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -45,33 +45,34 @@
 		if (response != "Regular" && response != "Carbon-Copy")
 			add_fingerprint(user)
 			return
-	if(amount >= 1)
-		amount--
-		if(amount==0)
-			update_icon()
 
-			var/obj/item/weapon/paper/P
-			if(papers.len > 0)	//If there's any custom paper on the stack, use that instead of creating a new paper.
-				P = papers[papers.len]
-				papers.Remove(P)
-			else
-				if(response == "Regular")
-					P = new /obj/item/weapon/paper
-					if(Holiday == "April Fool's Day")
-						if(prob(30))
-							P.info = "<font face=\"[P.crayonfont]\" color=\"red\"><b>HONK HONK HONK HONK HONK HONK HONK<br>HOOOOOOOOOOOOOOOOOOOOOONK<br>APRIL FOOLS</b></font>"
-							P.rigged = 1
-							P.updateinfolinks()
-				else if (response == "Carbon-Copy")
-					P = new /obj/item/weapon/paper/carbon
+	if(!amount==0)		//Eclipse edit
+		update_icon()
 
-			user.put_in_hands(P)
-			to_chat(user, SPAN_NOTICE("You take [P] out of the [src]."))
+		var/obj/item/weapon/paper/P
+		if(papers.len > 0)	//If there's any custom paper on the stack, use that instead of creating a new paper.
+			P = papers[papers.len]
+			papers.Remove(P)
 		else
-			to_chat(user, SPAN_NOTICE("[src] is empty!"))
+			if(response == "Regular")
+				P = new /obj/item/weapon/paper
+				if(Holiday == "April Fool's Day")
+					if(prob(30))
+						P.info = "<font face=\"[P.crayonfont]\" color=\"red\"><b>HONK HONK HONK HONK HONK HONK HONK<br>HOOOOOOOOOOOOOOOOOOOOOONK<br>APRIL FOOLS</b></font>"
+						P.rigged = 1
+						P.updateinfolinks()
+			else if (response == "Carbon-Copy")
+				P = new /obj/item/weapon/paper/carbon
 
-		add_fingerprint(user)
-		return
+		user.put_in_hands(P)
+		to_chat(user, SPAN_NOTICE("You take [P] out of the [src]."))
+		amount--
+		update_icon()
+	else
+		to_chat(user, SPAN_NOTICE("[src] is empty!"))
+
+	add_fingerprint(user)
+	return
 	.=..()
 
 //Pickup paperbins with drag n drop
@@ -92,8 +93,8 @@ obj/item/weapon/paper_bin/MouseDrop(over_object)
 	i.loc = src
 	to_chat(user, SPAN_NOTICE("You put [i] in [src]."))
 	papers.Add(i)
-	update_icon()
 	amount++
+	update_icon()		//Eclipse edit
 
 
 /obj/item/weapon/paper_bin/examine(mob/user)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -46,7 +46,7 @@
 			add_fingerprint(user)
 			return
 
-	if(!amount==0)		//Eclipse edit
+	if(!amount==0)			//Eclipse edit
 		update_icon()
 
 		var/obj/item/weapon/paper/P


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Paper bins will now display the correct sprite when there is paper in it or when it's empty.

- Paper bins will no longer claim to be empty upon server start.

- Paper bin sprites will now automatically update after a piece of paper is taken out or placed inside it.

Closes #235 

![image](https://user-images.githubusercontent.com/45645502/86398409-d658f000-bca5-11ea-96c8-14ba96191d68.png)
![image](https://user-images.githubusercontent.com/45645502/86398426-da850d80-bca5-11ea-8152-abe9015b23f0.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes an issue that prevented players from getting paper out of paper bins.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed paper bins not allowing players to take paper out of them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
