### PR TITLE
Current Character and occupation display on Main Menu

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -1,7 +1,7 @@
 #define ASSISTANT_TITLE "Vagabond"
 
 //Jobs depatment lists for use in constant expressions
-#define JOBS_SECURITY "Aegis Commander","Gunnery Sergeant","Aegis Inspector","Brig Physician","Aegis Operative"
+#define JOBS_SECURITY "Aegis Commander","Gunnery Sergeant","Aegis Inspector","Brig Physician","Aegis Operative","Aegis Medical Specialist"
 #define JOBS_COMMAND "Captain","Head of Personnel","Aegis Commander","Supply Manager","Chief Engineer","Chief Medical Officer","Chief Science Officer","Lazarus Representive"
 #define JOBS_ENGINEERING "Chief Engineer","Ship Engineer"
 #define JOBS_MEDICAL "Chief Medical Officer","Medical Doctor","Psychiatrist","Pharmacist","Paramedic"
@@ -25,7 +25,7 @@
 #define DEPARTMENT_CIVILIAN	"Civilian"
 #define DEPARTMENT_CHURCH	"Church"
 
-//Eclipse Additions for manual whitelist behaviour 
+//Eclipse Additions for manual whitelist behaviour
 //(refer to /code/game/jobs/job/job_eclipse.dm for manual and explanations)
 #define WHITELIST_AUTO 0
 #define WHITELIST_MANUAL_ON 1

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -338,6 +338,9 @@
 		panel = null
 	user << browse(null, "window=saves")
 
+	var/mob/new_player/np = client.mob
+	np.new_player_panel_proc()			//Eclipse edit. Automatic refresh for current character.
+
 /datum/preferences/proc/open_copy_dialog(mob/user)		//Eclipse edit.
 	var/dat = "<body>"
 	dat += "<tt><center>"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -83,6 +83,10 @@
 	S["version"] << SAVEFILE_VERSION_MAX
 	player_setup.save_character(S)
 	loaded_character = S
+
+	var/mob/new_player/np = client.mob
+	np.new_player_panel_proc()			//Eclipse edit. Automatic refresh for current character.
+
 	return S
 
 /datum/preferences/proc/overwrite_character(slot)			//Eclipse edit.

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -27,10 +27,43 @@
 	set src = usr
 	new_player_panel_proc()
 
-
+	/////BEGIN ECLIPSE EDIT/////
 /mob/new_player/proc/new_player_panel_proc()
-	var/output = "<div align='center'><B>New Player Options</B>"
-	output +="<hr>"
+	var/output = "<div align='center'><B><u>Current Character</B></u>"
+	output += "<br>"
+	output += "<div align='center'>[client.prefs.real_name]<br>"
+
+	var/department_color
+	if(ASSISTANT_TITLE in client.prefs.job_low)		//Vagabond is a special snowflake that gets checked first, hence job_low.
+		department_color = "#ffcb9e"
+	else if(client.prefs.job_high in engineering_positions)
+		department_color = "#e0ca22"
+	else if(client.prefs.job_high in medical_positions)
+		department_color = "#19ccd6"
+	else if(client.prefs.job_high in science_positions)
+		department_color = "#b344b3"
+	else if(client.prefs.job_high in cargo_positions)
+		department_color = "#ffaa00"
+	else if(client.prefs.job_high in civilian_positions)
+		department_color = "#77c932"
+	else if(client.prefs.job_high in security_positions)
+		department_color = "#dd3e40"
+	else if(client.prefs.job_high in nonhuman_positions)
+		department_color = "#fbadff"
+	else if(client.prefs.job_high in church_positions)
+		department_color = "#854500"
+	else if(client.prefs.job_high in command_positions)
+		department_color = "#0b60e8"
+	else
+		department_color = "#990014"
+
+	if(ASSISTANT_TITLE in client.prefs.job_low)		//If vagabond toggle is yes
+		output += "<font color=[department_color]>[ASSISTANT_TITLE]</font><br>"
+	else
+		output += "<font color=[department_color]>[client.prefs.job_high ? "[client.prefs.job_high]" : null]</font><br>"
+	/////END ECLIPSE EDIT/////
+
+	output += "<hr>"
 	output += "<p><a href='byond://?src=\ref[src];show_preferences=1'>Setup Character</A></p>"
 
 	if(SSticker.current_state <= GAME_STATE_PREGAME)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The player's currently selected character and their occupation will be displayed on the Main Menu for a quick reminder, without having to open the Character Setup menu to check. Their occupation will be in their department's respective colour.

All roles have been tested and an automatic refresher has been added so that it syncs correctly when loading a new character or saving changes to a current character's occupation.

(Big thanks to Kicks for helping me out!)

![image](https://user-images.githubusercontent.com/45645502/87808944-dbe43780-c85a-11ea-99e7-cf2f97591198.png) ![image](https://user-images.githubusercontent.com/45645502/87808956-dedf2800-c85a-11ea-9100-0c2bc998c6c1.png) ![image](https://user-images.githubusercontent.com/45645502/87808965-e1da1880-c85a-11ea-8ee3-71f1fcd5bfb6.png)
![image](https://user-images.githubusercontent.com/45645502/87808973-e56d9f80-c85a-11ea-9ff6-57bd03ad87da.png) ![image](https://user-images.githubusercontent.com/45645502/87808983-e7cff980-c85a-11ea-876f-2ed9105c9e42.png) ![image](https://user-images.githubusercontent.com/45645502/87808989-eb638080-c85a-11ea-9273-2297d7c09159.png) 
![image](https://user-images.githubusercontent.com/45645502/87808995-ee5e7100-c85a-11ea-8f23-827bf6c9c55c.png) ![image](https://user-images.githubusercontent.com/45645502/87809177-38475700-c85b-11ea-9360-7a7f1a5e6495.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It adds a quality of life change.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Currently selected character and their occupation is now displayed on the main menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
