### PR TITLE
adds tyrant storyteller

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2675,4 +2675,5 @@
 #include "zzz_modular_eclipse\gunvendor\gunkits.dm"
 #include "zzz_modular_eclipse\radio_sprites\radios.dm"
 #include "zzz_modular_eclipse\radio_squelch\radios.dm"
+#include "zzz_modular_eclipse\storytellers\tyrant.dm"
 // END_INCLUDE

--- a/zzz_modular_eclipse/storytellers/tyrant.dm
+++ b/zzz_modular_eclipse/storytellers/tyrant.dm
@@ -1,0 +1,20 @@
+/datum/storyteller/tyrant
+	config_tag = "tyrant"
+	name = "The Tyrant"
+	welcome = "The universe itself is against you. Stand with your friends and defy the stars."
+	description = "Ruthless storyteller that inspires unity in the crew by trying to crush them. Generates no antagonists."
+
+	gain_mult_mundane = 1.5
+	gain_mult_moderate = 1.5
+	gain_mult_major = 1.5
+	gain_mult_roleset = 0
+
+	tag_weight_mults = list(TAG_COMBAT = 1.6, TAG_DESTRUCTIVE = 1.2)
+
+	//Comrade generates a LOT of events, but never creates antagonists
+	points = list(
+	EVENT_LEVEL_MUNDANE = 50, //Mundane
+	EVENT_LEVEL_MODERATE = 50, //Moderate
+	EVENT_LEVEL_MAJOR = 80, //Major
+	EVENT_LEVEL_ROLESET = 0 //Roleset
+	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It adds a PvE (Player-versus-Environment) storyteller to the roster 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It will give players the option to activate a harsh storyteller that tries to kill them without having to worry about the paranoia involved with traitors, changelings and the occasional blitzshell mucking things up for everyone. It is meant to be quite difficult and should probably not be turned on without a full complement of departmental crew.
## Changelog
:cl:
add: Tyrant storyteller
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
