### PR TITLE
Whitelists jobs, patch for Aegis name prefixes

### DIFF
--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -8,12 +8,16 @@
 //Reginald spawn code on Eclipase Station code). Will be set TRUE after load.
 	var/eclipse_config_loaded = FALSE
 
-//job whitelisting.
+//job whitelisting. Prefix: "WhiteList"
 	var/usejobwhitelist = FALSE		//master job whitelisting enable
 	var/wl_heads = FALSE			//Whitelist Heads of Staff?
 	var/wl_security = FALSE			//Whitelist Security?
 	var/wl_silicons = FALSE			//Whitelist silicons?
 	var/wl_admins_too = FALSE		//Do admins go through whitelist checks?
+
+//Jobs required to start the round. Prefix: "Staff Requirement"
+	var/sr_bypass_command_requirement = FALSE		//Should we allow the round to start without a Head of Staff?
+	var/sr_lowpop_threshold = 10					//At what point are we no longer lowpop for the purposes of staff requirements?
 
 /hook/startup/proc/read_eclipse_config()
 	var/list/Lines = file2list("config/config_eclipse.txt")		//We don't want to add shit to the main config when we update this (merge conflicts)
@@ -51,6 +55,10 @@
 				config.wl_silicons = TRUE
 			if("admins_restricted_by_whitelist")
 				config.wl_admins_too = TRUE
+			if("bypass_head_of_staff_requirement")
+				config.sr_bypass_command_requirement = TRUE
+			if("staff_requirement_lowpop_threshold")
+				config.sr_lowpop_threshold = text2num(value)
 
 	config.eclipse_config_loaded = TRUE		//config is loaded
 

--- a/code/game/gamemodes/storyteller.dm
+++ b/code/game/gamemodes/storyteller.dm
@@ -88,19 +88,19 @@ GLOBAL_DATUM(storyteller, /datum/storyteller)
 				return TRUE
 
 	var/tcol = "red"
-	if(GLOB.player_list.len <= 10)
+	if(GLOB.player_list.len <= config.sr_lowpop_threshold)		//Eclipse edit: Config-based lowpop thresholds
 		tcol = "black"
 
 	if(announce)
-		if(!engineer && !command)
+		if(!engineer && (!command && !config.sr_bypass_command_requirement))		//Eclipse edit: config-based command requirement
 			to_chat(world, "<b><font color='[tcol]'>A command officer and engineer are required to start round.</font></b>")
 		else if(!engineer)
 			to_chat(world, "<b><font color='[tcol]'>An engineer is required to start round.</font></b>")
-		else if(!command)
+		else if(!command && !config.sr_bypass_command_requirement)		//Eclipse edit: Config-based command requirement
 			to_chat(world, "<b><font color='[tcol]'>A command officer is required to start round.</font></b>")
 
-	if(GLOB.player_list.len <= 10)
-		to_chat(world, "<i>But there's less than 10 players, so this requirement will be ignored.</i>")
+	if(GLOB.player_list.len <= config.sr_lowpop_threshold)		//Eclipse edit: Config-based lowpop thresholds.
+		to_chat(world, "<i>But there's less than [config.sr_lowpop_threshold] players, so this requirement will be ignored.</i>")
 		return TRUE
 
 	return FALSE

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -14,6 +14,8 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 	req_admin_notify = 1
 	wage = WAGE_NONE //The captain doesn't get paid, he's the one who does the paying
 	//The ship account is his, and he's free to draw as much salary as he likes
+	
+	wl_config_heads = TRUE		//Eclipse edit.
 
 
 	ideal_character_age = 70 // Old geezer captains ftw
@@ -80,6 +82,8 @@ Your second loyalty is to your command officers. The heads of each faction. List
 	wage = WAGE_COMMAND
 	also_known_languages = list(LANGUAGE_CYRILLIC = 20, LANGUAGE_SERBIAN = 15)
 	ideal_character_age = 50
+
+	wl_config_heads = TRUE		//Eclipse edit.
 
 	description = "You are the captain's right hand. His second in command. Where he goes, you follow. Where he leads, you drag everyone else along. You make sure his will is done, his orders obeyed, and his laws enforced.<br>\
 If he makes mistakes, discreetly inform him. Help to cover up his indiscretions and smooth relations with the crew, especially other command staff. Keep the captain safe, by endangering yourself in his stead if necessary.<br>\

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -13,6 +13,8 @@
 	also_known_languages = list(LANGUAGE_CYRILLIC = 100, LANGUAGE_SERBIAN = 25)
 	wage = WAGE_COMMAND
 	ideal_character_age = 50
+	
+	wl_config_heads = TRUE		//Eclipse edit.
 //	alt_titles = list()
 
 	outfit_type = /decl/hierarchy/outfit/job/engineering/exultant

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -12,6 +12,8 @@
 	req_admin_notify = 1
 	wage = WAGE_COMMAND
 	outfit_type = /decl/hierarchy/outfit/job/medical/cmo
+	
+	wl_config_heads = TRUE		//Eclipse edit.
 
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_genetics, access_heads,

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -12,6 +12,8 @@
 	req_admin_notify = 1
 	wage = WAGE_COMMAND
 	outfit_type = /decl/hierarchy/outfit/job/science/rd
+	
+	wl_config_heads = TRUE		//Eclipse edit.
 
 	access = list(
 		access_rd, access_heads, access_tox, access_genetics, access_morgue,

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -13,6 +13,9 @@
 	wage = WAGE_COMMAND
 
 	outfit_type = /decl/hierarchy/outfit/job/security/ihc
+	
+	wl_config_heads = TRUE		//Eclipse edit.
+	wl_config_sec = TRUE		//Eclipse edit.
 
 	access = list(
 		access_security, access_eva, access_sec_doors, access_brig, access_armory, access_medspec,
@@ -69,6 +72,8 @@
 	selection_color = "#a7bbc6"
 	department_account_access = TRUE
 	wage = WAGE_LABOUR_HAZARD
+	
+	wl_config_sec = TRUE		//Eclipse edit.
 
 	outfit_type = /decl/hierarchy/outfit/job/security/gunserg
 
@@ -120,6 +125,8 @@
 	supervisors = "the Aegis Commander"
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
+	
+	wl_config_sec = TRUE		//Eclipse edit.
 
 	outfit_type = /decl/hierarchy/outfit/job/security/inspector
 
@@ -175,6 +182,8 @@
 	supervisors = "the Aegis Commander"
 	selection_color = "#a7bbc6"
 	wage = WAGE_PROFESSIONAL
+	
+	wl_config_sec = TRUE		//Eclipse edit.
 
 	outfit_type = /decl/hierarchy/outfit/job/security/medspec
 
@@ -227,6 +236,8 @@
 	//alt_titles = list("Aegis Junior Operative")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
+	
+	wl_config_sec = TRUE		//Eclipse edit.
 
 	outfit_type = /decl/hierarchy/outfit/job/security/ihoper
 

--- a/code/game/jobs/job/silicon.dm
+++ b/code/game/jobs/job/silicon.dm
@@ -11,6 +11,9 @@
 	account_allowed = 0
 	wage = WAGE_NONE
 	outfit_type = /decl/hierarchy/outfit/job/silicon/ai
+	
+	wl_config_heads = TRUE		//Eclipse edit - AI is de-facto head over silicons.
+	wl_config_borgs = TRUE		//Eclipse edit.
 
 /datum/job/ai/equip(var/mob/living/carbon/human/H, var/alt_title)
 	return FALSE
@@ -41,6 +44,8 @@
 	selection_color = "#cdcfe0"
 	account_allowed = 0
 	wage = WAGE_NONE
+
+	wl_config_borgs = TRUE		//Eclipse edit.
 
 	outfit_type = /decl/hierarchy/outfit/job/silicon/cyborg
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -254,10 +254,18 @@ var/list/rank_prefix = list(\
 	)
 
 /mob/living/carbon/human/proc/rank_prefix_name(name)
+// // // BEGIN ECLIPSE EDITS // // //
+	var/no_space = TRUE		//is there no space in the name? Defaults to true unless we find a space
 	if(get_id_rank())
 		if(findtext(name, " "))
 			name = copytext(name, findtext(name, " "))
-		name = get_id_rank() + name
+			no_space = FALSE
+		
+		if(!no_space)		//if the name had a space (forename and surname), we don't need to do anything special
+			name = get_id_rank() + name
+		else				//If the name did not have a space (single-barrel name), we need to add a space
+			name = get_id_rank() + " " + name
+// // // END ECLIPSE EDITS // // //
 	return name
 
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a seperate proc as it'll be useful elsewhere

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -31,3 +31,20 @@
 ## Should silicons be whitelisted? This will not affect pAIs, only AI and borgs.
 ## Uncomment to whitelist.
 #WHITELIST_SILICONS
+
+#########
+# ROUNDSTART REQUIREMENTS
+#########
+
+## REQUIRE A HEAD OF STAFF
+## Should a head of staff be required for the round to start? By default, a head
+## of staff is required to start the round.
+## Uncomment to bypass this requirement.
+#BYPASS_HEAD_OF_STAFF_REQUIREMENT
+
+## HEAD OF STAFF AND ENGINEER LOWPOP THRESHOLD
+## When should we stop bypassing the requirements for an engineer and a head of
+## staff? This is done automatically to allow rounds with low population to be
+## played normally.
+## Default: 10
+STAFF_REQUIREMENT_LOWPOP_THRESHOLD 10


### PR DESCRIPTION
# ⚠️ WARNING: This PR contains config changes.

## About The Pull Request

Single-barrel names now display properly when playing as Captain or literally any of Security.

![image](https://user-images.githubusercontent.com/1784490/88344539-6b7d6080-cd09-11ea-86bf-a59df393a490.png)

Applies whitelisting and adds in a config option to bypass head of staff requirement.

![image](https://user-images.githubusercontent.com/1784490/88344657-ba2afa80-cd09-11ea-9b61-50a1826fb5e6.png)
*Note: In this screenshot, all whitelists are enabled. The whitelisting is divided between silicons, heads of staff, and security - each is separate.

![image](https://user-images.githubusercontent.com/1784490/88344602-92d42d80-cd09-11ea-9f16-0d3dd7a1533f.png)



## Why It's Good For The Game

нестор мап

## Changelog
:cl: EvilJackCarver
config: Adds configuration entries. Update config_eclipse.txt as necessary.
add: Implements whitelists.
fix: Aegis name prefixes should now play nice(r) with single-barrel names.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
