### PR TITLE
Nerfs/fixes(?) slimes

### DIFF
--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -66,7 +66,10 @@
 					if (!(C.species && (C.species.flags & NO_PAIN)))
 						to_chat(M, SPAN_DANGER("[painMes]"))
 
-			gain_nutrition(rand(20,25))
+			if(Victim.isMonkey()) //eclipse edit
+				gain_nutrition(rand(20,25)) //eclipse edit
+			else
+				gain_nutrition(rand(20,25) * 0.1) //eclipse edit
 
 			adjustOxyLoss(-8) //Heal yourself
 			adjustBruteLoss(-8)
@@ -117,7 +120,7 @@
 	if(!is_adult)
 		if(amount_grown >= 10)
 			is_adult = 1
-			maxHealth = 150
+			maxHealth = 80 //eclipse edit, used to be 150
 			amount_grown = 0
 			regenerate_icons()
 			name = text("[colour] [is_adult ? "adult" : "baby"] slime ([number])")

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -7,8 +7,8 @@
 	speak_emote = list("chirps")
 
 	layer = 5
-	maxHealth = 80
-	health = 80
+	maxHealth = 30
+	health = 30
 	gender = NEUTER
 
 	update_icon = 0
@@ -47,7 +47,7 @@
 	var/AIproc = 0 // If it's 0, we need to launch an AI proc
 	var/Atkcool = 0 // attack cooldown
 	var/SStun = 0 // NPC stun variable. Used to calm them down when they are attacked while feeding, or they will immediately re-attach
-	var/Discipline = 0 // if a slime has been hit with a freeze gun, or wrestled/attacked off a human, they become disciplined and don't attack anymore for a while. The part about freeze gun is a lie
+	var/Discipline = 0 // if a slime has been hit with a freeze gun, or wrestled/attacked off a human, they become disciplined and don't attack anymore for a while. The part about freeze gun is a lie // ALL OF THIS IS A FUCKING LIE
 
 	var/hurt_temperature = T0C-50 // slime keeps taking damage when its bodytemperature is below this
 	var/die_temperature = 50 // slime dies instantly when its bodytemperature is below this

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -7,8 +7,8 @@
 	speak_emote = list("chirps")
 
 	layer = 5
-	maxHealth = 30
-	health = 30
+	maxHealth = 40 //eclipse edit, used to be 80
+	health = 40 //eclipse edit ditto
 	gender = NEUTER
 
 	update_icon = 0

--- a/code/modules/reagents/reagents/core.dm
+++ b/code/modules/reagents/reagents/core.dm
@@ -17,7 +17,7 @@
 	if(data && data["blood_colour"])
 		color = data["blood_colour"]
 	return
-	
+
 /datum/reagent/organic/blood/get_data() // Just in case you have a reagent that handles data differently.
 	var/t = data.Copy()
 	if(t["virus2"])
@@ -96,7 +96,7 @@
 	glass_desc = "The father of all refreshments."
 	nerve_system_accumulations = 0
 	reagent_type = "Water"
-	
+
 /datum/reagent/water/touch_turf(var/turf/simulated/T)
 	if(!istype(T))
 		return TRUE
@@ -146,7 +146,7 @@
 /datum/reagent/water/affect_touch(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(isslime(M))
 		var/mob/living/carbon/slime/S = M
-		S.adjustToxLoss(0.8 * effect_multiplier) // Babies have 150 health, adults have 200; So, 10 units and 13.5
+		S.adjustToxLoss(2.8 * effect_multiplier) // Babies have 150 health, adults have 200; So, 10 units and 13.5
 		if(!S.client)
 			if(S.Target) // Like cats
 				S.Target = null

--- a/code/modules/reagents/reagents/core.dm
+++ b/code/modules/reagents/reagents/core.dm
@@ -146,7 +146,7 @@
 /datum/reagent/water/affect_touch(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(isslime(M))
 		var/mob/living/carbon/slime/S = M
-		S.adjustToxLoss(2.8 * effect_multiplier) // Babies have 150 health, adults have 200; So, 10 units and 13.5
+		S.adjustToxLoss(2.8 * effect_multiplier) // Babies have 150 health, adults have 200; So, 10 units and 13.5 // eclipse edit; disregard previous
 		if(!S.client)
 			if(S.Target) // Like cats
 				S.Target = null


### PR DESCRIPTION
After being jumped on and ganked by slimes a few too many times in the past week, I've decided to take a crack at fixing a few issues with them.

These include their high damage, high health, general-unfunness to play against.

This PR nerfs water doing a very pitiful amount of damage to slimes. Previously, water did .8 damage for every 1u applied to a slime. It now does 2.8- instead of doing 8 damage with a blast of a fire extinguisher, you now do 28. This is still too low in my opinion, but we'll see.

Also reduced base slime health from 80 to 30 so that it's **even possible** to kill them with normal weapons. 


:cl: 
tweak: fixes/nerfs slimes. Slimes no longer gain a billion nutrition while pouncing on someone unless said someone is A Monkey.
:cl: