### PR TITLE
Nerfs the everliving hell out of Fungo di Artiglieria spawning

### DIFF
--- a/code/controllers/subsystems/migration.dm
+++ b/code/controllers/subsystems/migration.dm
@@ -36,6 +36,7 @@ SUBSYSTEM_DEF(migration)
 	var/plantspread_burrows_num = 3 //How many other burrows will each one with plants send them to
 
 
+	var/last_fungus_growth = 0		//Eclipse edit: Putting this here for now. Deals with maint fungus spreading.
 
 /*************************************************
 	Burrow Creation

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -122,7 +122,17 @@
 		if(prob(chance))
 			sampled = 0
 
+	// // // BEGIN ECLIPSE EDITS // // //
+	//Maintenance fungus spread nerfs.
+	
+	//If the seed is our favourite maintenance fungus and the world time is less than 60 seconds after our last growth, abort
+	if(seed.name == "fungoartiglieria" && (world.time < SSmigration.last_fungus_growth + 60 SECONDS))	//this gives us up to 60 growths per hour.
+		return
+
 	if(is_mature() && neighbors.len && prob(spread_chance))
+		if(seed.name == "fungoartiglieria"
+			SSmigration.last_fungus_growth = world.time			//Set our last growth time to world time.
+	// // // END ECLIPSE EDITS // // //
 		spawn()
 			spread()
 

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -130,7 +130,7 @@
 		return
 
 	if(is_mature() && neighbors.len && prob(spread_chance))
-		if(seed.name == "fungoartiglieria"
+		if(seed.name == "fungoartiglieria")
 			SSmigration.last_fungus_growth = world.time			//Set our last growth time to world time.
 	// // // END ECLIPSE EDITS // // //
 		spawn()


### PR DESCRIPTION
## About The Pull Request

Caps maintenance fungus spreading at roughly 60 per hour.

## Changelog
:cl: EvilJackCarver
tweak: Maintenance mushrooms should no longer overwhelm the crew.
/:cl:

Screenshot of it, after I added some debug code:

![image](https://user-images.githubusercontent.com/1784490/88384274-b92db380-cd71-11ea-91ad-3c2c4f80b170.png)

![image](https://user-images.githubusercontent.com/1784490/88384232-aa470100-cd71-11ea-87c2-0de924f67fa3.png)

(Note: "RTC" in the debug text is short for "realtime clock", AKA system clock. World time is in hh:mm format.)
