### PR TITLE
tweaks trash piles to be slightly less annoying

### DIFF
--- a/code/modules/scrap/scrap.dm
+++ b/code/modules/scrap/scrap.dm
@@ -242,7 +242,9 @@ GLOBAL_LIST_EMPTY(scrap_base_cache)
 			return FALSE
 		if(victim.gloves && prob(90))
 			return FALSE
-		var/obj/item/organ/external/BP = victim.get_organ(victim.hand ? BP_L_ARM : BP_R_ARM)
+		if(victim.wear_suit && istype(victim.wear_suit, /obj/item/clothing/suit/space)) //Eclipse edit: if getting cut through the spacesuit doesn't somehow depressurize it, then it should not cut you at all
+			return
+		var/obj/item/organ/external/BP = victim.get_organ(victim.hand ? BP_L_HAND : BP_R_HAND) //Eclipse edit: changed these to hands instead of arms because Eris doesn't have hands and we do
 		if(!BP)
 			return FALSE
 		if(BP_IS_ROBOTIC(BP))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This adjusts the 'failure' of looting trash piles so that it actually cuts your hands instead of your arms when a bad roll is made. It also makes it impossible to cut yourself while searching through trash piles if you are wearing a space suit.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
This is good because you won't have to suspend disbelief when a pile of empty candy wrappers somehow slices your arm open through your voidsuit and does not kill you through instant depressurization of your personal atmospheric containment outfit. It also didn't make much sense that a full-body suit covering your hands... would fail to cover your hands.
## Changelog
:cl:
add: wearing a space suit will prevent trash piles from cutting your hands
fix: trash piles will correctly cut your hands instead of your arms when you are digging through them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
