### PR TITLE
Fixes an issue where players could join despite being not whitelisted

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -341,6 +341,13 @@
 		if(job && IsJobAvailable(job.title))
 			if(job.is_restricted(client.prefs))
 				continue
+			// // // BEGIN ECLIPSE EDITS // // //
+			//Jobban/job whitelist fixes
+			if(job.whitelist_only && !is_job_whitelisted(client, job.title))	//do they not pass whitelist?
+				continue
+			if(jobban_isbanned(client, job.title))			//are they banned?
+				continue
+			// // // END ECLIPSE EDITS // // //
 			var/active = 0
 			// Only players with the job assigned and AFK for less than 10 minutes count as active
 			for(var/mob/M in GLOB.player_list) if(M.mind && M.client && M.mind.assigned_role == job.title && M.client.inactivity <= 10 * 60 * 10)


### PR DESCRIPTION
## About The Pull Request
Adds checks so that players won't be able to select a role they're not whitelisted for in the latejoin menu. Tested while also testing the dispatcher code.

## Changelog
:cl: EvilJackCarver
fix: Fixed an issue where players could join as a job they weren't whitelisted for, albeit with vagabond-level access.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
