### PR TITLE
Un-duplicates organs on regen

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1186,10 +1186,11 @@ var/list/rank_prefix = list(\
 		qdel(CI)
 
 */
+	for(var/obj/item/organ/organ in (organs|internal_organs)) //Whoops
+		qdel(organ)
 
 	if(from_preference)
-		for(var/obj/item/organ/organ in (organs|internal_organs))
-			qdel(organ)
+
 
 		if(organs.len)
 			organs.Cut()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the bug that causes people to have double organs.

## Why It's Good For The Game

People no longer collapse from lack of blood to fuel all their organs.

## Changelog
:cl:
fix: Rejuvenation-like effects (vat, cloning, aheal) no longer cause the character to have duplicate sets of organs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
