### PR TITLE
Adds the option to make a gender-neutral character

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -349,7 +349,7 @@ ADMIN_VERB_ADD(/client/proc/respawn_character, R_FUN, FALSE)
 		new_character.age = record_found.fields["age"]
 		new_character.b_type = record_found.fields["b_type"]
 	else
-		new_character.gender = pick(MALE,FEMALE)
+		new_character.gender = pick(MALE,FEMALE,PLURAL)
 		var/datum/preferences/A = new()
 		A.randomize_appearance_and_body_for(new_character)
 		new_character.real_name = G_found.real_name
@@ -458,7 +458,7 @@ ADMIN_VERB_ADD(/client/proc/cmd_admin_rejuvenate, R_ADMIN, FALSE)
 	if(!istype(M))
 		alert("Cannot revive a ghost")
 		return
-		
+
 	M.revive()
 
 	log_admin("[key_name(usr)] healed / revived [key_name(M)]")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -50,7 +50,7 @@
 //	if(!length(GLOB.skills))
 //		decls_repository.get_decl(/decl/hierarchy/skill)
 	player_setup = new(src)
-	gender = pick(MALE, FEMALE)
+	gender = pick(MALE, FEMALE, PLURAL)
 	family_name = random_last_name(species)									//Eclipse Edit
 	real_name = random_first_name(gender,species) + " " + family_name		//Re-work surname into clanname
 	b_type = RANDOM_BLOOD_TYPE

--- a/code/modules/mob/gender.dm
+++ b/code/modules/mob/gender.dm
@@ -43,6 +43,18 @@
 	is   = "is"
 	does = "does"
 
+/datum/gender/neutral
+	key  = "neutral"
+
+	He   = "They"
+	he   = "they"
+	His  = "Their"
+	his  = "their"
+	him  = "them"
+	has  = "have"
+	is   = "are"
+	does = "do"
+
 /datum/gender/neuter
 	key = "neuter"
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -773,10 +773,12 @@ var/list/rank_prefix = list(\
 	if(new_style)
 		f_style = new_style
 
-	var/new_gender = alert(usr, "Please select gender.", "Character Generation", "Male", "Female")
+	var/new_gender = alert(usr, "Please select gender.", "Character Generation", "Male", "Female", "Neutral")
 	if (new_gender)
 		if(new_gender == "Male")
 			gender = MALE
+		if(new_gender == "Neutral")
+			gender = PLURAL
 		else
 			gender = FEMALE
 	regenerate_icons()

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -174,7 +174,7 @@
 		)
 
 	// Misc
-	var/list/genders = list(MALE, FEMALE)
+	var/list/genders = list(MALE, FEMALE, PLURAL)
 
 	// Bump vars
 	var/bump_flag = HUMAN	// What are we considered to be when bumped?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In the alert menu used to select a character's gender, "plural" is now an option. It's what it says on the tin; pick this, and the character will be described with they/them pronouns. Want to make a non-binary character? Sure, do it. Want your custom species to not necessarily follow a strict male/female binary? Go ahead. Generally, this will cause the game to default to handling the character as would be the default when it comes to name generation and such.
(Note: Plural is perhaps not the _most_ accurate term, but it works and it seems to be pretty hard-baked in. My brain is not wrinkly enough to make it "_neutral_" just yet.)
(Other Note: If this sees strong use/there's demand, I can look into making sex and gender selectable separately. For now, however, biological sex seems to be represented solely in flavour.)
(Other Other Note: Not that kind of flavour, the RP kind.)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This allows players more freedom in their character design and makes character creation more representative of real-world demographics. Besides, on a ship full of genemodders, FBPs and aliens, it's plausible that going by they/them wouldn't be too outlandish, right?

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: "Plural" option to the gender alert box.
tweak: Various bits of code to make plural selectable as a gender by default.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
