### PR TITLE
Carrion regen fix

### DIFF
--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -241,13 +241,18 @@
 			owner.rejuvenate()
 			for(var/limb_tag in owner.species.has_limbs)
 				var/obj/item/organ/external/E = owner.get_organ(limb_tag)
-				if(E.is_stump())
-					qdel(E)
+				if(E)
+					if(E.is_stump())
+						qdel(E)
+						var/datum/organ_description/OD = owner.species.has_limbs[limb_tag]
+						OD.create_organ(owner)
+				else
 					var/datum/organ_description/OD = owner.species.has_limbs[limb_tag]
 					OD.create_organ(owner)
 
 			owner.status_flags &= ~(FAKEDEATH)
 			owner.update_lying_buckled_and_verb_status()
+			owner.update_body()
 			owner.update_icons()
 			to_chat(owner, SPAN_NOTICE("You have regenerated."))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
 
 Carrion regeneration no longer paralyzes the poor spooder
 
## Why It's Good For The Game

Bubg feex

## Changelog
:cl:
fix: Carrions are no longer forever paralyzed by regenerative stasis
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
