### PR TITLE
Empty Hands update

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -246,6 +246,16 @@
 		src.drop_from_inventory(r_hand)
 	if (l_hand && l_hand.canremove)
 		src.drop_from_inventory(l_hand)
+	// Disown, but don't drop because we can get here with UI elements and probably other things.
+	if (r_hand && r_hand.loc != usr)
+		if (client) client.screen.Remove(r_hand)
+		r_hand = null
+	if (l_hand && l_hand.loc != usr)
+		if (client) client.screen.Remove(r_hand)
+		l_hand = null
+	// Still there? Double-check it's supposed to be removable before calling admins to debug.
+	if ((r_hand && r_hand.canremove) || (l_hand && l_hand.canremove))
+		message_admins("[usr.name] has something removable stuck in their hand after using empty hands! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 
 /mob/verb/pointed(atom/A as mob|obj|turf in view())
 	set name = "Point To"


### PR DESCRIPTION
Makes Empty Hands a bit more forceful about it. Calls admins if it fails when it shouldn't.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Just an improvement to the Empty hands verb
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

There's a number of bugs that can lead to items being stuck in your hand when they shouldn't be. This should, in theory, provide a workaround, as well as giving people a single button to empty both hands quickly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Made Empty Hands go nuclear if the item in your hand is actually somewhere else.
admin: Empty Hands will now send a message to online admins if it fails to remove something removable from a person's hand.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
