### PR TITLE
Fix drag and drop to disposal

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -216,6 +216,13 @@
 		if(!I)
 			return
 
+		// ensure it's on the ground first, so we don't break things, also so we have a chance to interact with the air we're passing through.
+		if(istype(I.loc,/obj/item/weapon/storage))
+			var/obj/item/weapon/storage/oldLoc = I.loc
+			oldLoc.remove_from_storage(I)
+		if(I.loc == usr && !user.unEquip(I))
+			return FALSE
+
 		I.add_fingerprint(user)
 		I.forceMove(src)
 		to_chat(user, "You place \the [I] into the [src].")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds checks to try to ensure the item being moved to the disposal is on a turf, rather than in an object. We do this because forceMove does not trigger any UI updates, and we want to retain moving things from turfs into disposal at some things can't be put in the disposal otherwise.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This fixes a bug where players could easily get items stuck in their hand, as well as a visual bug with disposaling items out of storage containers, without clobbering existing functions.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: disposal units now properly remove items from their prior location when you drag and drop the item onto the disposal.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
