### PR TITLE
Aegis compliance patch

### DIFF
--- a/code/game/objects/random/ammo.dm
+++ b/code/game/objects/random/ammo.dm
@@ -24,12 +24,12 @@
 	spawn_nothing_percentage = 60
 
 /obj/spawner/ammo/ihs
-	name = "random ironhammer ammunition"
+	name = "random aegis ammunition"
 	icon_state = "ammo-blue"
 	tags_to_spawn = list(SPAWN_AMMO_IH)
 
 /obj/spawner/ammo/ihs/low_chance
-	name = "low chance random random ironhammer ammunition"
+	name = "low chance random random aegis ammunition"
 	icon_state = "ammo-blue-low"
 	spawn_nothing_percentage = 60
 

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -43,7 +43,7 @@
 	desc = "Standard operative suit issued to Aegis mercenaries. Provides balanced overall protection against various threats and widely used on planets surface, space stations or in open space."
 	icon_state = "ihs_rig"
 	helm_type = /obj/item/clothing/head/space/rig/combat/ironhammer
-	suit_type = "ironhammer hardsuit"
+	suit_type = "aegis hardsuit"
 	spawn_blacklisted = TRUE//antag_item_targets
 
 /obj/item/weapon/rig/combat/ironhammer/equipped


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Renames Ironhammer ammo and hardsuit to Aegis. This appears to finalize aegis compliance for strings.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Lore Compliance

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Aegis ammo and hardsuit no longer claim to belong to Ironhammer.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
