### PR TITLE
Null runtime fixes

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -85,7 +85,7 @@
 	loaded_character = S
 
 	var/mob/new_player/np = client.mob
-	np.new_player_panel_proc()			//Eclipse edit. Automatic refresh for current character.
+	if (np) np.new_player_panel_proc()			//Eclipse edit. Automatic refresh for current character.
 
 	return S
 

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -72,13 +72,14 @@ var/global/obj/machinery/power/eotp/eotp
 
 	if(world.time >= (last_rescan + rescan_cooldown) && length(scanned))
 		var/mob/living/carbon/human/H = pick(scanned)
-		var/obj/item/weapon/implant/core_implant/I = H.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform)
-		if(I && I.active && I.wearer)
-			eotp.removeObservation(20)
-		else if(is_carrion(H))
-			eotp.addObservation(20)
-		else
-			eotp.removeObservation(10)
+		if(H) // scanned sometimes contains null entries.
+			var/obj/item/weapon/implant/core_implant/I = H.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform)
+			if(I && I.active && I.wearer)
+				eotp.removeObservation(20)
+			else if(is_carrion(H))
+				eotp.addObservation(20)
+			else
+				eotp.removeObservation(10)
 
 		scanned.Remove(H)
 		last_rescan = world.time


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Slips in an extra check in a couple places to avoid trying to do work with null values.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

While the preferences one has little to no impact, the EOTP one impacts processing because the nulls aren't removed after causing the runtime.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed a couple of runtimes, including one for the Eye of the Protector.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
