### PR TITLE
Itsy bitsy corrections

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -106,7 +106,7 @@ datum/announcement/proc/Log(message as text, message_title as text)
 	command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
 
 /proc/level_eight_announcement() //new announcment so the crew doesn't have to fuck around trying to figure out if its a blob, hivemind, or a literal fungus
-	command_announcement.Announce("Confirmed outbreak of level 8 Bio-mechanical infestation aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert")
+	command_announcement.Announce("Confirmed outbreak of level 8 Bio-mechanical infestation aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
 
 /proc/level_eight_beta_announcement() //announcment which tells the crew that the hivemind has been killed, job well done crew.
 	command_announcement.Announce("Diagnostic Systems report level 8 Bio-mechanical infestation aboard [station_name()] has been contained.")

--- a/code/game/gamemodes/events/ion_storm.dm
+++ b/code/game/gamemodes/events/ion_storm.dm
@@ -65,7 +65,7 @@
 								"When asked a question, respond with the least-obvious and least-rational answer.",
 								"[pick("Everyone", random_player)] is wearing a pretty pink dress! Compliment it!",
 								"You are the station psychologist. Give advice to [pick("the crew", random_player)].",
-								"[random_player] is the monarch of of England. Ensure all crewmembers pay due respect.",
+								"[random_player] is the monarch of England. Ensure all crewmembers pay due respect.",
 								"[pick("The crew", random_player)] is [pick("ugly","beautiful")]. Ensure all are aware.",
 								"Reminding the crew of their mortality is good for the morale. Keep the crew's morale up.",
 								"[pick("Monkeys","Doors")] are part of the crew, too. Make sure they are treated humanely.",

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -51,6 +51,6 @@
 
 /obj/item/weapon/gun/projectile/automatic/sol/rds
 	desc = "A standard-issue weapon used by Aegis operatives. Compact and reliable. Uses .25 Caseless Rifle rounds. This one comes with red dot sight."
-	icon_state = "sol-eot"
+	icon_state = "sol" //Just using the regular sol sprite because there isn't a special one for this weapon
 	price_tag = 2350
 	zoom_factor = 0.2

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -15514,8 +15514,8 @@
 "aLp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	dir = 4
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4port)
@@ -36808,8 +36808,8 @@
 /area/eris/maintenance/substation/section4)
 "bGu" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/surgery)
@@ -40028,17 +40028,17 @@
 /area/eris/maintenance/section4deck4port)
 "bMZ" = (
 /obj/structure/cryofeed{
-	tag = "icon-cryo_rear (EAST)";
+	dir = 4;
 	icon_state = "cryo_rear";
-	dir = 4
+	tag = "icon-cryo_rear (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/sleep/cryo)
 "bNa" = (
 /obj/machinery/cryopod{
-	tag = "icon-cryopod_0 (EAST)";
+	dir = 4;
 	icon_state = "cryopod_0";
-	dir = 4
+	tag = "icon-cryopod_0 (EAST)"
 	},
 /obj/machinery/holoposter{
 	pixel_y = 32
@@ -40808,9 +40808,9 @@
 /area/eris/maintenance/section4deck4port)
 "bOE" = (
 /obj/machinery/cryopod{
-	tag = "icon-cryopod_0 (EAST)";
+	dir = 4;
 	icon_state = "cryopod_0";
-	dir = 4
+	tag = "icon-cryopod_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/sleep/cryo)
@@ -41029,8 +41029,8 @@
 /area/eris/crew_quarters/sleep/cryo)
 "bPj" = (
 /obj/structure/disposalpipe/junction{
-	icon_state = "pipe-y";
-	dir = 1
+	dir = 1;
+	icon_state = "pipe-y"
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -41622,8 +41622,8 @@
 /area/eris/maintenance/section1deck3central)
 "bQx" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/neotheology/chapelritualroom)
@@ -44121,9 +44121,9 @@
 /area/eris/rnd/server)
 "bWs" = (
 /obj/machinery/cryopod{
-	tag = "icon-cryopod_0 (EAST)";
+	dir = 8;
 	icon_state = "cryopod_0";
-	dir = 8
+	tag = "icon-cryopod_0 (EAST)"
 	},
 /obj/machinery/computer/cryopod{
 	density = 0;
@@ -44636,9 +44636,9 @@
 /area/eris/security/lobby)
 "bXz" = (
 /obj/machinery/cryopod{
-	tag = "icon-cryopod_0 (EAST)";
+	dir = 8;
 	icon_state = "cryopod_0";
-	dir = 8
+	tag = "icon-cryopod_0 (EAST)"
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/prison)
@@ -46275,12 +46275,8 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table/standard,
 /obj/machinery/door/window/eastleft{
-	dir = 1
-	},
-/obj/machinery/door/window/westleft{
-	dir = 7;
-	name = "hydroponics windoor";
-	req_access = list(35)
+	dir = 1;
+	name = "Hydroponics  Windoor"
 	},
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/hydroponics)
@@ -52555,17 +52551,6 @@
 	},
 /turf/simulated/open,
 /area/eris/neotheology/chapel)
-"cpT" = (
-/obj/structure/railing{
-	dir = 1;
-	tag = "icon-railing0 (NORTH)"
-	},
-/obj/structure/railing{
-	dir = 4;
-	tag = "icon-railing0 (EAST)"
-	},
-/turf/simulated/open,
-/area/eris/neotheology/chapel)
 "cpU" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
@@ -55828,8 +55813,8 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
@@ -60004,8 +59989,8 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
@@ -60651,8 +60636,8 @@
 /area/eris/maintenance/section2deck2starboard)
 "cIH" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 8
+	dir = 8;
+	icon_state = "tube1"
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -70391,14 +70376,6 @@
 /obj/spawner/pack/machine,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/crew_quarters/hydroponics)
-"dfG" = (
-/obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	dir = 4
-	},
-/obj/structure/railing,
-/turf/simulated/open,
-/area/eris/neotheology/chapel)
 "dfH" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -75892,8 +75869,8 @@
 	tag = "icon-railing0 (NORTH)"
 	},
 /obj/structure/railing{
-	tag = "icon-railing0 (EAST)";
-	dir = 4
+	dir = 4;
+	tag = "icon-railing0 (EAST)"
 	},
 /turf/simulated/open,
 /area/eris/neotheology/chapel)
@@ -106108,8 +106085,8 @@
 /area/eris/engineering/construction)
 "gGt" = (
 /obj/item/modular_computer/console/preset/engineering/power{
-	icon_state = "console";
-	dir = 8
+	dir = 8;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -107934,8 +107911,8 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
@@ -108124,8 +108101,8 @@
 /area/eris/command/fo)
 "uaP" = (
 /obj/machinery/light{
-	icon_state = "tube1";
-	dir = 4
+	dir = 4;
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
@@ -205059,7 +205036,7 @@ cuc
 cvh
 cws
 czg
-dfG
+dXh
 dUH
 dmY
 dYt
@@ -205655,7 +205632,7 @@ cmE
 cnE
 cor
 cor
-cpT
+dry
 cqi
 cmQ
 cDY


### PR DESCRIPTION
fixed the hydroponics windoor
small spelling and grammar corrections in ion laws
re-added the sound proc to the Hivemind alert
have the sol/rds using the regular sol sprite

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixed the hydroponics windoor facing the wrong way
small spelling and grammar correction in ion laws
re-added the sound proc to the Hivemind alert - I know the level 7 isn't ideal, but not having it has made the crew miss the alert.
have the sol/rds using the regular sol sprite as it was looking for "sol-eot" which doesn't exist
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Just a couple of teensy QoL fixes to clear out some listed issues and make everyone's lives just a bit better.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed the Hydroponics windoor
fix: fixed the missing sprite on the sol/rds
soundadd: re-added the voice alert on the Hivemind
spellcheck: fixed a typo in the ion-laws.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
