### PR TITLE
adds synthetic brains

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -121,7 +121,7 @@ var/global/list/organ_tag_to_name = list(
 	eyes  = "eyes", l_arm = "left arm", l_hand = "left hand",
 	groin = "groin",l_leg = "left leg", l_foot = "left foot",
 	chest2= "back", heart = "heart",    lungs  = "lungs",
-	liver = "liver"
+	liver = "liver", brain = "brain"
 	)
 
 // Visual nets

--- a/code/modules/client/preference_setup/augmentation/01_modifications.dm
+++ b/code/modules/client/preference_setup/augmentation/01_modifications.dm
@@ -2,7 +2,7 @@
 	var/list/modifications_data   = list()
 	var/list/modifications_colors = list()
 	var/current_organ = BP_CHEST
-	var/global/list/r_organs = list(BP_HEAD, BP_R_ARM, BP_R_HAND, BP_CHEST, BP_R_LEG, BP_R_FOOT)
+	var/global/list/r_organs = list(BP_HEAD, BP_BRAIN, BP_R_ARM, BP_R_HAND, BP_CHEST, BP_R_LEG, BP_R_FOOT)
 	var/global/list/l_organs = list(BP_EYES, BP_L_ARM, BP_L_HAND, BP_GROIN, BP_L_LEG, BP_L_FOOT)
 	var/global/list/internal_organs = list("chest2", OP_HEART, OP_LUNGS, OP_LIVER)
 

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -95,3 +95,9 @@
 	desc = "A tightly furled roll of paper, covered with indecipherable runes."
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "scroll"
+
+/obj/item/organ/internal/brain/synth
+	name = "humanoid positronic brain"
+	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. This particular model is designed to be used in humanoid chassis."
+	icon = 'icons/obj/assemblies.dmi'
+	icon_state = "posibrain-occupied"

--- a/code/modules/organs/body_modifications.dm
+++ b/code/modules/organs/body_modifications.dm
@@ -3,7 +3,8 @@ var/global/list/modifications_types = list(
 	BP_CHEST = "",  "chest2" = "", BP_HEAD = "",   BP_GROIN = "",
 	BP_L_ARM  = "", BP_R_ARM  = "", BP_L_HAND = "", BP_R_HAND = "",
 	BP_L_LEG  = "", BP_R_LEG  = "", BP_L_FOOT = "", BP_R_FOOT = "",
-	OP_HEART  = "", OP_LUNGS  = "", OP_LIVER  = "", OP_EYES   = ""
+	OP_HEART  = "", OP_LUNGS  = "", OP_LIVER  = "", OP_EYES   = "",
+	BP_BRAIN  = ""
 )
 
 /proc/generate_body_modification_lists()
@@ -328,5 +329,17 @@ var/global/list/modifications_types = list(
 	body_parts = list(BP_HEAD)
 	replace_limb = /obj/item/organ/external/robotic
 	icon = 'icons/mob/human_races/cyberlimbs/unbranded/unbranded_monitor.dmi'
+	nature = MODIFICATION_SILICON
+	allow_nt = FALSE
+
+// Synth brains
+
+/datum/body_modification/organ/brain/posibrain
+	name = "Positronic brain"
+	id = "carbonposibrain"
+	short_name = "Positronic brain"
+	desc = "An artificial mind, typically used in silicon beings. This particular model is designed to be used in humanoid chassis."
+	body_parts = list(BP_BRAIN)
+	replace_limb = /obj/item/organ/internal/brain/synth
 	nature = MODIFICATION_SILICON
 	allow_nt = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
They're cubes! They're intelligent! They're... positronic brains, now available in _your_ character from roundstart! 
"Humanoid positronic brain" is now an option under augmentation. Works just like an organic brain in every way other than being synthetic.

I understand this may need to be talked over.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
There's been some demand for this as an option, and it doesn't provide any significant balance or gameplay changes. And hey, if we can put a posibrain into a 'borg, why can't we pop it into an empty body or humanoid chassis?

## Changelog
:cl:
add: "Humanoid positronic brains" as an option available under the Augmentation submenu in character creation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
