### PR TITLE
Drone laws and Spacevines

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -84,8 +84,9 @@
 
 /datum/ai_laws/drone/New()
 	add_inherent_law("Preserve, repair and improve the ship to the best of your abilities.")
-	add_inherent_law("Cause no harm to the ship or anything on it.")
-	add_inherent_law("Interact with no being that is not a fellow maintenance drone.")
+	add_inherent_law("Prevent unplanned damage to your assigned vessel wherever possible. You are considered part of the vessel.")
+	add_inherent_law("Ensure the eradication of any Biohazard of Level 6 or higher. Fulfillment of this law overrides all other laws.")
+	add_inherent_law("Do not interact or interfere with any being that is not a fellow maintenance drone unless doing so is required to fulfill an above law.")
 	..()
 
 /datum/ai_laws/construction_drone

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -102,6 +102,9 @@ datum/announcement/proc/Log(message as text, message_title as text)
 	// Format currently matches that of newscaster feeds: Registered Name (Assigned Rank)
 	return I.assignment ? "[I.registered_name] ([I.assignment])" : I.registered_name
 
+/proc/level_six_announcement()
+	command_announcement.Announce("Confirmed outbreak of level 6 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
+
 /proc/level_seven_announcement()
 	command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
 

--- a/code/game/gamemodes/events/spacevine.dm
+++ b/code/game/gamemodes/events/spacevine.dm
@@ -27,6 +27,6 @@
 	spacevines_spawned = 1
 
 /datum/event/spacevine/announce()
-	level_seven_announcement()
+	level_six_announcement()
 
 


### PR DESCRIPTION
Updates drone laws to provide clearer instructions. Including how to respond to a blob/hivemind
Reduces Spacevines to a level 6 biohazard, separating them from the Blob.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Updates drone laws to provide clearer instructions. Including how to respond to a blob/hivemind
Reduces Spacevines to a level 6 biohazard, separating them from the Blob.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives our industrious maintenance drones clearer instructions on how to act in different situations. Also separating the Blob and Spacevines into separate alerts helps players as these two represent very different threats and require very different responses from the crew
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a new "Level 6 Biohazard," for spacevines
del: Removed old things
tweak: replaced drone laws with a custom set courtesy of the Lore Team.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
