### PR TITLE
itsy bitsy corrections

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -109,7 +109,7 @@ datum/announcement/proc/Log(message as text, message_title as text)
 	command_announcement.Announce("Confirmed outbreak of level 7 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
 
 /proc/level_eight_announcement() //new announcment so the crew doesn't have to fuck around trying to figure out if its a blob, hivemind, or a literal fungus
-	command_announcement.Announce("Confirmed outbreak of level 8 Bio-mechanical infestation aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert")
+	command_announcement.Announce("Confirmed outbreak of level 8 Bio-mechanical infestation aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", new_sound = 'sound/AI/outbreak7.ogg')
 
 /proc/level_eight_beta_announcement() //announcment which tells the crew that the hivemind has been killed, job well done crew.
 	command_announcement.Announce("Diagnostic Systems report level 8 Bio-mechanical infestation aboard [station_name()] has been contained.")

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -51,6 +51,6 @@
 
 /obj/item/weapon/gun/projectile/automatic/sol/rds
 	desc = "A standard-issue weapon used by Aegis operatives. Compact and reliable. Uses .25 Caseless Rifle rounds. This one comes with red dot sight."
-	icon_state = "sol-eot"
+	icon_state = "sol" //Just using the regular sol sprite because there isn't a special one for this weapon
 	price_tag = 2350
 	zoom_factor = 0.2

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -46366,11 +46366,8 @@
 "cbw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/standard,
-/obj/machinery/door/window/eastleft{
-	dir = 1
-	},
 /obj/machinery/door/window/westleft{
-	dir = 7;
+	dir = 1;
 	name = "hydroponics windoor";
 	req_access = list(35)
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fucked up the original pull request and accidentally deleted the branch, whoops! here it is again, with 100% less conflicts!
fixed the hydroponics windoor facing the wrong way
re-added the sound proc to the Hivemind alert - I know the level 7 isn't ideal, but not having it has made the crew miss the alert.
have the sol/rds using the regular sol sprite as it was looking for "sol-eot" which doesn't exist
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Just a couple of teensy QoL fixes to clear out some listed issues and make everyone's lives just a bit better.
fixes issues: #1395 and #1407 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed the Hydroponics windoor
fix: fixed the missing sprite on the sol/rds
soundadd: re-added the voice alert on the Hivemind
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
