### PR TITLE
fix inspector ID access to allow forensics

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -133,7 +133,7 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/security/inspector
 
-	access = list(access_security, access_moebius, access_medspec, access_engine, access_mailsorting, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks)
+	access = list(access_security, access_moebius, access_medspec, access_engine, access_mailsorting, access_eva, access_sec_doors, access_forensics_lockers, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks)
 
 	stat_modifiers = list(
 		STAT_BIO = 15,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Readded access_forensics_lockers to access list for Inspector job
Fix #1456 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This access is required for inspector to access gear and do job
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Readded forensic access to Inspector
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
