### PR TITLE
Fixes the code that nerfed the ever-living hell out of maintenance mushrooms, tweaked rate of spread

### DIFF
--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -128,12 +128,12 @@
 	// // // BEGIN ECLIPSE EDITS // // //
 	//Maintenance fungus spread nerfs.
 	
-	//If the seed is our favourite maintenance fungus and the world time is less than 60 seconds after our last growth, abort
-	if(seed.name == "fungoartiglieria" && (world.time < SSmigration.last_fungus_growth + 60 SECONDS))	//this gives us up to 60 growths per hour.
+	//If the seed is our favourite maintenance fungus and the world time is less than 30 seconds after our last growth, abort
+	if(istype(seed, /datum/seed/mushroom/maintshroom) && (world.time < SSmigration.last_fungus_growth + 30 SECONDS))	//this gives us up to 120 growths per hour.
 		return
 
 	if(is_mature() && neighbors.len && prob(spread_chance))
-		if(seed.name == "fungoartiglieria")
+		if(istype(seed, /datum/seed/mushroom/maintshroom))
 			SSmigration.last_fungus_growth = world.time			//Set our last growth time to world time.
 	// // // END ECLIPSE EDITS // // //
 		spawn()


### PR DESCRIPTION

## About The Pull Request

Re-work of #404 to work with the different types of mushrooms, instead of limiting only the one. Adjusted timer to 30 seconds, so it's not quite as bad a nerf.

At some point I plan to move the rate of growth over to the config, but this is just a quick hotfix for nonfunctional code.

## Changelog
:cl: EvilJackCarver
fix: Fix the code that originally nerfed the maintenance mushrooms' growth rate.
tweak: Doubled the rate that the original nerf allowed maintenance mushrooms to grow at. (Now 120/hour max, from 60/hour max)
/:cl:

Screenshot of test, with debug code added. Yes, they all tried to spread at the exact same time.
![image](https://user-images.githubusercontent.com/1784490/114306304-28cf0480-9aa1-11eb-9c62-400700cdf746.png)


