### PR TITLE
Fire/air alarm audibles no longer play if unable

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -891,6 +891,8 @@
 		return
 	last_sound_time = world.time
 	for(var/i in 1 to 3)		//plays 3 times always.
+		if((stat & (NOPOWER|BROKEN)) || shorted || buildstage != 2)		//Check again here in case the power was cut while the audibles were going off.
+			return
 		playsound(src.loc, 'sound/misc/airalarm.ogg', 40, 0, 5)
 		sleep(4 SECONDS)
 
@@ -1227,6 +1229,8 @@ FIRE ALARM
 	var/area/coverage_area = get_area(src)
 	for(var/i in 1 to rand(4,6))		//plays 4 to 6 times.
 		if (!coverage_area.fire)
+			return
+		if(stat & (NOPOWER|BROKEN))		//Check again in case the power was cut while the audible loop was running
 			return
 		playsound(src.loc, 'sound/misc/firealarm.ogg', 40, 0, 5)
 		sleep(4 SECONDS)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -887,6 +887,8 @@
 
 // Eclipse proc - added to reduce impact to Process() call
 /obj/machinery/alarm/proc/play_audible()
+	if((stat & (NOPOWER|BROKEN)) || shorted || buildstage != 2)		//Don't play audibles if we can't play audibles (no power, broken, et cetera)
+		return
 	last_sound_time = world.time
 	for(var/i in 1 to 3)		//plays 3 times always.
 		playsound(src.loc, 'sound/misc/airalarm.ogg', 40, 0, 5)
@@ -1219,7 +1221,9 @@ FIRE ALARM
 
 //Eclipse proc - added to reduce overhead on Process()
 /obj/machinery/firealarm/proc/play_audible()
-	last_sound_time = world.time		//at the stert to prevent overlap
+	if(stat & (NOPOWER|BROKEN))		//Don't play audibles if we can't play audibles (no power or broken)
+		return
+	last_sound_time = world.time		//at the start to reduce overlap
 	var/area/coverage_area = get_area(src)
 	for(var/i in 1 to rand(4,6))		//plays 4 to 6 times.
 		if (!coverage_area.fire)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Air alarm and fire alarm audibles will no longer sound if they're depowered or otherwise unable to (e.g. broken, shorted, etc). If they're in the middle of a three-buzz "run", the run will finish before it is silenced due to technical limitations.

## Changelog
:cl: EvilJackCarver
fix: Fire and air alarm audibles will no longer play if depowered, broken, et cetera
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->


Raw video from test: https://www.youtube.com/watch?v=_Dp07e4lOuE