### PR TITLE
Makes inflatables not stop the hivemind wires

### DIFF
--- a/code/modules/hivemind/wires.dm
+++ b/code/modules/hivemind/wires.dm
@@ -191,12 +191,12 @@
 
 		if(locate(/obj/structure) in target)
 			for(var/obj/structure/S in target)
-				if(S.density && S.anchored)
+				if(S.density && S.anchored && !(istype(S, /obj/structure/inflatable))) //Makes it so anchored inflatables do NOT block the hivemind wires. TODO: Make it play a message/sound when
+				//The wires go around the inflatables
 					return FALSE
 
 		if(locate(/obj/machinery/door) in target)
 			return FALSE
-
 		return TRUE
 	else
 		return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your Pull Request fixes an issue, please write "Fixes #1234" or "Closes #5678" so the issue automatically closes when the PR is merged. For more information, see Contributing.MD for further information. --->
Makes the strange wires go underneath the inflatable barriers/doors for balancing sake.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Makes hivemind less trivial to deal with when deploying inflatables. Fixes #1259 
## Changelog
:cl:
fix: Allows hivemind's strange wires to spread underneath of the inflatable barriers. Makes it harder to deal with the hive mind.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
