### PR TITLE
Lockers in ZeroG Fix

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -185,6 +185,8 @@
 	for(var/obj/O in orange(1, src))
 		if(O.density && O.anchored)
 			return TRUE
+		if(istype(O, /obj/structure/closet) && O.density)
+			return TRUE
 
 	return FALSE
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your Pull Request fixes an issue, please write "Fixes #1234" or "Closes #5678" so the issue automatically closes when the PR is merged. For more information, see Contributing.MD for further information. --->
Changes the way density for the sake of ZeroG checks for pushing off, to allow for closed lockers to be push points in zeroG. Directly fixes #409
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Allows places that players normally get stuck in to be points to push off of in ZeroG, therefore closing that gap. Also, fixes aforementioned Issue.
## Changelog
:cl:

fix: Makes closed lockers push-points for ZeroG

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
