### PR TITLE
Fixes and balancing changes to roaches, with regards to hats

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
@@ -78,6 +78,7 @@
 			F.distress_call()
 		if(hat)
 			hat.loc = get_turf(src)
+			hat.update_plane()		//Eclipse edit: update the hat's plane so it's not glowing.
 			hat = null
 			update_hat()
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/roach.dm
@@ -65,9 +65,10 @@
 
 /mob/living/carbon/superior_animal/roach/New()
 	. = ..()
-	var/newhat = pick(hats4roaches)
-	var/obj/item/hatobj = new newhat(loc)
-	wear_hat(hatobj)
+	if(prob(5))		//Eclipse edit: 5% chance to wear a hat. Hopefully the hat economy shall no longer be flooded.
+		var/newhat = pick(hats4roaches)
+		var/obj/item/hatobj = new newhat(loc)
+		wear_hat(hatobj)
 
 
 //When roaches die near a leader, the leader may call for reinforcements


### PR DESCRIPTION
## About The Pull Request
* Roaches now only have a slim chance to spawn wearing a hat.
* Roach hats no longer glow in the dark when dropped.

![image](https://user-images.githubusercontent.com/1784490/119078337-997c1180-b9bb-11eb-846f-2631bb4489f2.png)
*In this screenshot, only one roach is visible wearing a hat (upper left two tiles across from the bottle of liquor, wearing the brown flat cap). After a `gib()` call, another hat was visible in the pile.*

## Why It's Good For The Game

Collectible hats now have scarcity (and some value), and fixes an issue where hats would be above the lighting plane.

## Changelog
:cl: EvilJackCarver
balance: Roaches' collectible hats now only have a 5% chance to spawn.
fix: Roaches' hats no longer glow in the dark when dropped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
