### PR TITLE
Adds a GPS tracker to all drones.

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/_drone.dm
@@ -63,6 +63,8 @@ var/list/mob_hat_cache = list()
 	var/communication_channel = LANGUAGE_DRONE
 	var/station_drone = TRUE
 
+	var/obj/item/device/gps/satnav		//Eclipse edit: Drones (and blitzshells) now have a satnav.
+
 	holder_type = /obj/item/weapon/holder/drone
 
 /mob/living/silicon/robot/drone/can_be_possessed_by(var/mob/observer/ghost/possessor)
@@ -96,6 +98,11 @@ var/list/mob_hat_cache = list()
 /mob/living/silicon/robot/drone/Destroy()
 	if(hat)
 		hat.loc = get_turf(src)
+	// // // BEGIN ECLIPSE EDITS // // //
+	// Destroy our satnav if we die.
+	if(satnav)
+		satnav.Destroy()
+	// // // END ECLIPSE EDITS // // //
 	GLOB.drones.Remove(src)
 	. = ..()
 
@@ -154,7 +161,16 @@ var/list/mob_hat_cache = list()
 	name = real_name
 
 /mob/living/silicon/robot/drone/updatename()
-	real_name = "maintenance drone ([rand(100,999)])"
+	// // // BEGIN ECLIPSE EDITS // // //
+	// Satellite navigator ID
+	var/random_id = rand(100,999)
+	satnav = new /obj/item/device/gps(src)
+	satnav.gps.prefix = "DRNE"
+	if(satnav)		//null check
+		satnav.gps.change_serial("DRNE-[random_id]")
+		satnav.update_name()
+	real_name = "maintenance drone ([random_id])"
+	// // // END ECLIPSE EDITS // // //
 	name = real_name
 
 /mob/living/silicon/robot/drone/updateicon()
@@ -353,7 +369,16 @@ var/list/mob_hat_cache = list()
 	flavor_text = "It's a bulky construction drone stamped with a Sol Central glyph."
 
 /mob/living/silicon/robot/drone/construction/updatename()
-	real_name = "construction drone ([rand(100,999)])"
+	// // // BEGIN ECLIPSE EDITS // // //
+	// Satellite navigator ID
+	var/random_id = rand(100,999)
+	satnav = new /obj/item/device/gps(src)
+	satnav.gps.prefix = "DRNE"
+	if(satnav)		//null check
+		satnav.gps.change_serial("DRNE-[random_id]")
+		satnav.update_name()
+	real_name = "construction drone ([random_id])"
+	// // // END ECLIPSE EDITS // // //
 	name = real_name
 
 /mob/living/silicon/robot/drone/construction/updateicon()

--- a/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
+++ b/code/modules/mob/living/silicon/robot/drone/blitzshell.dm
@@ -12,7 +12,16 @@
 	ai_access = FALSE
 
 /mob/living/silicon/robot/drone/blitzshell/updatename()
-	real_name = "\"Blitzshell\" assault drone ([rand(100,999)])"
+	// // // BEGIN ECLIPSE EDITS // // //
+	// Satellite navigator ID
+	var/random_id = rand(100,999)
+	satnav = new /obj/item/device/gps(src)
+	satnav.gps.prefix = "DRNE"
+	if(satnav)		//null check
+		satnav.gps.change_serial("DRNE-[random_id]")
+		satnav.update_name()
+	real_name = "\"Blitzshell\" assault drone ([random_id])"
+	// // // END ECLIPSE EDITS // // //
 	name = real_name
 
 /mob/living/silicon/robot/drone/blitzshell/is_allowed_vent_crawl_item()


### PR DESCRIPTION
## About The Pull Request
Adds a GPS to all drones, allowing players to track them easier.

## Why It's Good For The Game
From what I've seen of them, Blitzshell drone encounters tend to follow the route of "30 seconds of Benny Hill, 5 minutes of hiding". The goal here is to reduce the hiding and make it more Benny Hill, since trying to find someone or something hiding on the ship without a way to locate them is tedium (at best).

In order to prevent this balancing change from favouring the players too much, all drones - maintenance drones, construction drones, and Blitzshell drones - all share the same GPS prefix, `DRNE`. This favours the drone slightly if there's also maintenance drones on the ship, giving players false leads. However, attentive players will be able to tell the drones apart by looking at the number on the drone, as the GPS number and the drone number are the same.

![image](https://user-images.githubusercontent.com/1784490/119090831-ba4f6180-b9d1-11eb-80da-42860056d7b7.png)
*Twenty-odd drones in a room. The Blitzshell is the sixth or seventh one down the list, with the tag "DRNE-658".*

Security's locator will *not* pick up the drone tags.

## Changelog
:cl: EvilJackCarver
add: All drones now have a GPS tracker.
/:cl:


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
