### PR TITLE
Lowpop Hivemind balancing pass

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1124,7 +1124,7 @@ FIRE ALARM
 	
 	//Eclipse Edit: alarm loops now.
 	var/area/coverage_area = get_area(src)
-	if (coverage_area.fire && world.time > last_sound_time + alarm_audible_cooldown)
+	if (coverage_area.fire && (world.time > (last_sound_time + alarm_audible_cooldown)))
 		play_audible()
 	return
 
@@ -1217,6 +1217,7 @@ FIRE ALARM
 		visible_message("[usr] resets \the [src].", "You have reset \the [src].")
 	else
 		to_chat(usr, "Fire Alarm is reset.")
+	last_sound_time = 0		//Eclipse edit: Allow us to make a sound immediately as it triggers next time it's triggered.
 	update_icon()
 	return
 
@@ -1231,7 +1232,13 @@ FIRE ALARM
 	else
 		to_chat(usr, "Fire Alarm activated.")
 	update_icon()
-	play_audible()			//Eclipse edit: beep beep beep. beep beep beep.
+	
+	// // // BEGIN ECLIPSE EDITS // // //
+	//Fix fire alarms going batshit insane if automatically triggered
+	if (area.fire && (world.time > (last_sound_time + alarm_audible_cooldown)))
+		play_audible()
+	// // // END ECLIPSE EDITS // // //
+
 	return
 
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1117,12 +1117,43 @@ FIRE ALARM
 
 	if(locate(/obj/fire) in loc)
 		alarm()
-
+	
+	var/hivemind = check_for_hivemind()		//Eclipse edit: Hivemind stuff interferes with the equipment. That's the handwave I'm using for this balancing change. ^Spitzer
+	if(hivemind)
+		alarm()
+	
 	//Eclipse Edit: alarm loops now.
 	var/area/coverage_area = get_area(src)
 	if (coverage_area.fire && world.time > last_sound_time + alarm_audible_cooldown)
 		play_audible()
 	return
+
+// // // BEGIN ECLIPSE EDITS // // //
+/obj/machinery/firealarm/proc/check_for_hivemind()
+	//First get the number of active players, since that determines range it can see.
+	var/crew = 0		//start it at zero
+	
+	for(var/mob/M in GLOB.player_list)
+		if(M.client && M.mind && M.stat != DEAD && (ishuman(M) || isrobot(M) || isAI(M)))
+			var/datum/job/job = SSjob.GetJob(M.mind.assigned_role)
+			if(job)
+				crew++
+	
+	var/calculated_range = max((7 - crew), 1)
+	
+	if(crew > 7)	//Crew is larger than 7, so we won't see anything anyway.
+		return FALSE
+	
+	if(locate(/obj/machinery/hivemind_machine) in view(calculated_range, src.loc))		//We saw a hivemind machine.
+		return TRUE
+	
+	if(locate(/obj/effect/plant/hivemind) in view(calculated_range, src.loc)) //We see floor wires
+		return TRUE
+		
+	//We don't detect anything, so return false so we don't pop an alarm.
+	return FALSE
+	
+// // // END ECLIPSE EDITS // // //
 
 /obj/machinery/firealarm/power_change()
 	..()

--- a/code/modules/hivemind/machines.dm
+++ b/code/modules/hivemind/machines.dm
@@ -83,9 +83,6 @@
 		else
 			throw EXCEPTION("Invalid switch statement case, expected positive integer and got [players]")		//Always add some form of error handling, kids.
 	health = health_percent * max_health		//Set the health proportional to our new maximum health
-	
-	log_debug("[src] debug: end health [health] end max health [max_health] proportion [(health/max_health) * 100]%")
-
 
 /obj/machinery/hivemind_machine/Process()
 	process_ticks++		//increment our tick counter
@@ -96,7 +93,6 @@
 		SDP.check_conditions()
 
 	if(!(process_ticks % 10))		//Every ten ticks, check for players and adjust our health accordingly.
-		log_debug("[src] adjusting health at PTick [process_ticks]")
 		adjust_health()
 
 	if(hive_mind_ai && !(stat & EMPED) && !is_on_cooldown() && (player_check() > 3))		//we want more than 3 players online before we regenetate.

--- a/code/modules/hivemind/machines.dm
+++ b/code/modules/hivemind/machines.dm
@@ -68,8 +68,6 @@
 	var/health_percent = health/max_health		//Get a proportion of maximum health prior to adjusting for player count
 	var/players = player_check()
 	
-	log_debug("[src] debug: PC [player_check()] PV [players] Start health [health] start max health [max_health] proportion [health_percent * 100]%")
-	
 	switch(players)
 		if(0 to 2)		//Fixed 50% regen speed, 75% health
 			max_health = initial(max_health) * 0.75

--- a/code/modules/hivemind/machines.dm
+++ b/code/modules/hivemind/machines.dm
@@ -29,10 +29,15 @@
 	var/time_until_regen = 0
 	var/obj/assimilated_machinery
 	var/obj/item/weapon/electronics/circuitboard/saved_circuit
+	
+	//Eclipse-added vars
+	var/regen_speed = REGENERATION_SPEED		//Used in health scaling.
+	var/process_ticks = 0						//Used in determining when to adjust health for players on
 
 /obj/machinery/hivemind_machine/Initialize()
 	. = ..()
 	name_pick()
+	adjust_health()		//Eclipse edit: Adjust maximum health.
 	health = max_health
 	set_light(2, 3, illumination_color)
 
@@ -44,18 +49,63 @@
 	else
 		icon_state = initial(icon_state)
 
+// // // BEGIN ECLIPSE EDITS // // //
+// Scale machine health based on number of players.
+/obj/machinery/hivemind_machine/proc/player_check()
+	var/crew = 0		//start it at zero
+	
+	for(var/mob/M in GLOB.player_list)
+		if(M.client && M.mind && M.stat != DEAD && (ishuman(M) || isrobot(M) || isAI(M)))
+			var/datum/job/job = SSjob.GetJob(M.mind.assigned_role)
+			if(job)
+				crew++
+	
+	return crew
+
+/obj/machinery/hivemind_machine/proc/adjust_health()
+	if(max_health < 5)		//Don't adjust health if we're that weak
+		return
+	var/health_percent = health/max_health		//Get a proportion of maximum health prior to adjusting for player count
+	var/players = player_check()
+	
+	log_debug("[src] debug: PC [player_check()] PV [players] Start health [health] start max health [max_health] proportion [health_percent * 100]%")
+	
+	switch(players)
+		if(0 to 2)		//Fixed 50% regen speed, 75% health
+			max_health = initial(max_health) * 0.75
+			regen_speed = REGENERATION_SPEED * 0.5
+		if(3 to 10)		//Regeneration speed and health on linear scale based on player count
+			var/healthcalc = 0.75 + ((0.25/8) * (players - 3))
+			max_health = initial(max_health) * healthcalc
+			var/regen_calc = 0.5 + ((0.5/8) * (players - 3))
+			regen_speed = REGENERATION_SPEED * regen_calc
+		if(11 to INFINITY)	//Fixed 100% regen speed and health
+			max_health = initial(max_health)
+			regen_speed = REGENERATION_SPEED
+		else
+			throw EXCEPTION("Invalid switch statement case, expected positive integer and got [players]")		//Always add some form of error handling, kids.
+	health = health_percent * max_health		//Set the health proportional to our new maximum health
+	
+	log_debug("[src] debug: end health [health] end max health [max_health] proportion [(health/max_health) * 100]%")
+
 
 /obj/machinery/hivemind_machine/Process()
+	process_ticks++		//increment our tick counter
 	if(wireweeds_required && !locate(/obj/effect/plant/hivemind) in loc)
 		take_damage(5, on_damage_react = FALSE)
 
 	if(SDP)
 		SDP.check_conditions()
 
-	if(hive_mind_ai && !(stat & EMPED) && !is_on_cooldown())
+	if(!(process_ticks % 10))		//Every ten ticks, check for players and adjust our health accordingly.
+		log_debug("[src] adjusting health at PTick [process_ticks]")
+		adjust_health()
+
+	if(hive_mind_ai && !(stat & EMPED) && !is_on_cooldown() && (player_check() > 3))		//we want more than 3 players online before we regenetate.
+	// // // END ECLIPSE EDITS // // //
 		//slow health regeneration
 		if(can_regenerate && (health != max_health) && (world.time > time_until_regen))
-			health += REGENERATION_SPEED
+			health += regen_speed		//Eclipse edit: use adjusted regen speed rather than define
 			if(health > max_health)
 				health = max_health
 
@@ -475,19 +525,26 @@
 
 	var/mob/living/target = locate() in targets_in_range(world.view, in_hear_range = TRUE)
 	if(target && target.stat != DEAD && target.faction != HIVE_FACTION)
-		use_ability()
-		set_cooldown()
+// // // BEGIN ECLIPSE EDITS // // //
+		if(use_ability())		//If we didn't successfully spawn a mob, don't set a cooldown so we can try again
+			set_cooldown()
 
 
 /obj/machinery/hivemind_machine/mob_spawner/use_ability()
 	var/obj/randomcatcher/CATCH = new /obj/randomcatcher(src)
 	var/mob/living/simple_animal/hostile/hivemind/spawned_mob = CATCH.get_item(mob_to_spawn)
+
+//If we have less than so many players on, don't spawn certain mobs.
+	if(spawned_mob.maxHealth > 75 * player_check())
+		qdel(spawned_mob)
+		return FALSE		//We didn't successfully spawn a mob.
 	spawned_mob.loc = loc
 	spawned_creatures.Add(spawned_mob)
 	spawned_mob.master = src
 	flick("[icon_state]-anim", src)
 	qdel(CATCH)
-
+	return TRUE		//We did successfuly spawn a mob, so the cooldown (above) will be set.
+// // // END ECLIPSE EDITS // // //
 
 
 //MACHINE PREACHER

--- a/code/modules/hivemind/mobs.dm
+++ b/code/modules/hivemind/mobs.dm
@@ -29,12 +29,54 @@
 	//internals
 	var/obj/machinery/hivemind_machine/master
 	var/special_ability_cooldown = 0		//use ability_cooldown, don't touch this
+	
+	//eclipse added vars
+	var/life_ticks = 0		//Number of Life() ticks, used in automated health scaling calculations
 
 
-	New()
-		. = ..()
-		//here we change name, so design them according to this
-		name = pick("Warped ", "Altered ", "Modified ", "Upgraded ", "Abnormal ") + name
+/mob/living/simple_animal/hostile/hivemind/New()		//Eclipse Edit: MoS
+	. = ..()
+	
+// // // BEGIN ECLIPSE EDITS // // //
+// Balancing changes for lowpop hivemind.
+
+//If we have less than so many players on, don't spawn certain mobs.
+	if(initial(maxHealth) > (75 * player_check()))
+		src.death()		//This seems the best way to do this...
+	adjust_health()		//Also, adjust our health while we're here so we aren't overpowered if we do sapwn in
+	
+	//here we change name, so design them according to this
+	name = pick("Warped ", "Altered ", "Modified ", "Upgraded ", "Abnormal ") + name
+
+//Proc to get number of players active, for balancing.
+//Returns number of active crew.
+/mob/living/simple_animal/hostile/hivemind/proc/player_check()
+	var/crew = 0		//start it at zero
+	
+	for(var/mob/M in GLOB.player_list)
+		if(M.client && M.mind && M.stat != DEAD && (ishuman(M) || isrobot(M) || isAI(M)))
+			var/datum/job/job = SSjob.GetJob(M.mind.assigned_role)
+			if(job)
+				crew++
+	
+	return crew
+
+/mob/living/simple_animal/hostile/hivemind/proc/adjust_health()
+	if(health < 5)		//Don't adjust health if we're this bloody weak...
+		return
+
+	var/health_percent = health/maxHealth		//Get a proportion of maximum health prior to adjusting for player count
+	var/players = player_check()
+	
+	switch(players)
+		if(0 to 2)
+			maxHealth = initial(maxHealth) * 0.75
+		if(3 to 10)
+			var/healthcalc = 0.75 + ((0.25/8) * (players - 3))
+			maxHealth = initial(maxHealth) * healthcalc
+		if(11 to INFINITY)
+			maxHealth = initial(maxHealth)
+	health = health_percent * maxHealth		//Set the health appropriately so it still has the same percentage as it did before
 
 //It's sets manually
 /mob/living/simple_animal/hostile/hivemind/proc/special_ability()
@@ -101,6 +143,13 @@
 /mob/living/simple_animal/hostile/hivemind/Life()
 	if(stat == DEAD)
 		return
+	
+	// // // BEGIN ECLIPSE EDITS // // //
+	//Dynamic health scaling to player count.
+	life_ticks++
+	if(!life_ticks % 5)		//every few life ticks, so we don't bog everything down
+		adjust_health()
+	// // // END ECLIPSE EDITS // // //
 	. = ..()
 
 	speak()

--- a/code/modules/hivemind/mobs.dm
+++ b/code/modules/hivemind/mobs.dm
@@ -39,10 +39,6 @@
 	
 // // // BEGIN ECLIPSE EDITS // // //
 // Balancing changes for lowpop hivemind.
-
-//If we have less than so many players on, don't spawn certain mobs.
-	if(initial(maxHealth) > (75 * player_check()))
-		src.death()		//This seems the best way to do this...
 	adjust_health()		//Also, adjust our health while we're here so we aren't overpowered if we do sapwn in
 	
 	//here we change name, so design them according to this
@@ -62,7 +58,7 @@
 	return crew
 
 /mob/living/simple_animal/hostile/hivemind/proc/adjust_health()
-	if(health < 5)		//Don't adjust health if we're this bloody weak...
+	if(maxHealth < 5)		//Don't adjust health if we're this bloody weak...
 		return
 
 	var/health_percent = health/maxHealth		//Get a proportion of maximum health prior to adjusting for player count

--- a/code/modules/hivemind/mobs.dm
+++ b/code/modules/hivemind/mobs.dm
@@ -143,7 +143,7 @@
 	// // // BEGIN ECLIPSE EDITS // // //
 	//Dynamic health scaling to player count.
 	life_ticks++
-	if(!life_ticks % 5)		//every few life ticks, so we don't bog everything down
+	if(!(life_ticks % 10))		//every few life ticks, so we don't bog everything down
 		adjust_health()
 	// // // END ECLIPSE EDITS // // //
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some rebalancing tweaks to make Hivemind less of a round-ending event during lowpop.

### Definitions

For the sake of this pull request,

* The phrase "active players" means any mob that:
  * Has a connected client
  * Has a mind datum
  * Is not deceased
  * Is a human, AI, or cyborg mobtype
  * Has a job assignment

### Health Changes

* Mobs and machines now scale in health based on the number of active players. This is recalculated every tenth `Life()` and `Process()` tick for mobs and machines, respectively.
* Health and maximum health are scaled differently depending on number of active players, and have a floor of 75% and a ceiling of 100% of their default values.
  * If there are fewer than 2 active players, their maximum health is a flat 25% reduction from their original values.
  * If there are 3 to 10 active players, their maximum health is 75%, plus one-eighth of 25% for each active player, minus three active players (`0.75 + ((0.25/8) * (active_players - 3))`). This means that at 6 active players, their maximum health is 84.375% of their original values.
  * If there are more than 10 active players, their maximum health is a flat 100% of their original values.
  * Any damage they have taken is recalculated as a percentage of their maximum health. 
    * For example, if a mob with 125 maximum health is brought down to 75 health (60% health), and the mob's maximum health is then scaled to be 100, the mob will have 60 health (60% of 100). Similarly, if a mob with 100 maximum health is brought down to 80 health (80% health) and the maximum health is then scaled to be 150, the mob will have 120 health (80% of 150).
  * **Health and maximum health scaling does not affect mobs or machines with an initial maximum health of 5 or less.**
* Machine health regeneration per tick (AKA regeneration rate) is similarly scaled, with a floor of 50% and a ceiling of 100% of their default values.
  * If there are fewer than 2 active players, their regeneration rate is a flat 50% reduction of their original values.
  * If there are 3 to 10 active players, their regeneration rate is 50%, plus one-eight of of 25% for each active player, minus three active players (`0.50 + ((0.50/8) * (active_players - 3))`). This means that at 8 active players, their regeneration rate is 81.375% of their original values.
  * If there are more than 10 active players, their regeneration rate is a flat 100% of their original values.

#### Mob spawning

* Mobs spawned by the Assembler will only spawn if their health is less than 75 times the number of active players. This means that for an Assembler to be able to spawn a mob with 500 health, there will need to be at least 7 players on (6×75 == 450; 7×75 == 525). Mobs that are spawned that do not pass this check are immediately qdel'd. If the mob is qdel'd, it doesn't reset the cooldown and the Assembler will be able to attempt to spawn another. ***This needs further testing that I'm unable to do solo.***
* Mobs spawned outside of via the Assembler (e.g. admin shenanigans, random spawns) are not subject to the maximum health restriction, but will have their health scaled appropriately, as that's in the `Life()` proc. 

### Fire alarm changes

* If there are fewer than 7 active players, fire alarms will go into alarm state if they detect a hivemind machine or turf, due to (mumble mumble something about interference and the nature of electronics).
* A fire alarm's ability to detect hivemind machinery or turf scales with the number of active players.
  * The scale is a linear 7 tiles, minus one tile for each active player (the larger value of `7 - active_players` or 1) with a floor of 1 and ceiling of 7 tiles. 
  * If there are more than 7 active players, fire alarms will not detect hivemind turfs or machinery.
* Fire alarms do not care about hivemind mobs.
* Fixes an issue where fire alarms that are automatically triggered will go absolutely batshit insane.

## Why It's Good For The Game

Lowpop hivemind has been a round-ender for quite some time. Hopefully, this balancing pass doesn't make it piss-easy, but rather a threat the crew can actually *tackle*.

Forgot to get screenshots during testing, that one's on me, but I do have a video from the fire alarm test.

## Changelog
:cl: EvilJackCarver
balance: Hivemind should no longer be round-ending for low-population rounds.
balance: Hivemind mobs' and machines' maximum health scale based on active players, with a floor of 75% and ceiling of 100%.
balance: Hivemind machines' health regeneration per Process() tick now scales based on active players, with a floor of 50% and a ceiling of 100%.
balance: Hivemind machines and turfs now interfere with fire alarms if there are fewer than 7 active players.
balance: Assembler spawns are now restricted based on the maximum health of the spawned mob and the number of active players.
fix: Fire alarms that are automatically triggered will no longer repeatedly play their audibles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
