### PR TITLE
Fixes dispatcher not caring about latejoin players

### DIFF
--- a/code/controllers/subsystems/dispatcher.dm
+++ b/code/controllers/subsystems/dispatcher.dm
@@ -131,7 +131,6 @@ SUBSYSTEM_DEF(dispatcher)
 			log_debug("DISPATCHER: Finished scheduled update.")
 
 /datum/controller/subsystem/dispatcher/Recover()
-	flags |= SS_NO_INIT // We don't want to init twice.
 	flush_tracking()
 
 /datum/controller/subsystem/dispatcher/proc/flush_tracking()

--- a/code/controllers/subsystems/dispatcher_debug.dm
+++ b/code/controllers/subsystems/dispatcher_debug.dm
@@ -224,5 +224,5 @@ ADMIN_VERB_ADD(/client/proc/dump_tracking, R_DEBUG, FALSE)
 	message_admins("Player tracking data dump completed in [timer] seconds. Saved as '[dump_log]'.")
 	log_admin("Player tracking data dump completed.")
 	
-	if(fexists(dump_log)
+	if(fexists(dump_log))
 		src << run( file(dump_log) )

--- a/code/controllers/subsystems/dispatcher_debug.dm
+++ b/code/controllers/subsystems/dispatcher_debug.dm
@@ -220,6 +220,9 @@ ADMIN_VERB_ADD(/client/proc/dump_tracking, R_DEBUG, FALSE)
 	WRITE_LOG(dump_log, " # END OF CONTENT")
 	
 	SSdispatcher.ptrack_dump_in_progress = FALSE
-	to_chat(usr, "<span class='danger'>PTrack dump completed in [timer] seconds. Saved to server as '[dump_log]'.</span>")
+	to_chat(usr, "<span class='danger'>PTrack dump completed in [timer] seconds. Saved to server as '[dump_log]'. Stand by for clientside download. This may take some time...</span>")
 	message_admins("Player tracking data dump completed in [timer] seconds. Saved as '[dump_log]'.")
 	log_admin("Player tracking data dump completed.")
+	
+	if(fexists(dump_log)
+		src << run( file(dump_log) )

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -150,6 +150,8 @@
 	if(M.buckled && istype(M.buckled, /obj/structure/bed/chair/wheelchair))
 		M.buckled.forceMove(M.loc)
 		M.buckled.set_dir(M.dir)
+		
+	SSDispatcher.add_to_tracking(M)		//Eclipse edit: Add to dispatcher tracking.
 	return TRUE
 
 /datum/spawnpoint/nosearch //for when we want people to start on the exact tile of the spawn landmark
@@ -196,6 +198,8 @@
 
 		//When spawning in cryo, you start off asleep for a few moments and wake up
 		M.Paralyse(2)
+		
+		SSDispatcher.add_to_tracking(M)		//Eclipse edit: Add to dispatcher tracking.
 
 		//You can get yourself out of the cryopod, or it will auto-eject after one minute
 		spawn(600)
@@ -255,6 +259,8 @@
 		M.Paralyse(2)
 
 		//Once you wake up, you can get yourself out of bed. I've made it real easy, just click basically anything
+		
+		SSDispatcher.add_to_tracking(M)		//Eclipse addition: Add to dispatcher tracking.
 
 		return TRUE
 	return FALSE

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -151,7 +151,7 @@
 		M.buckled.forceMove(M.loc)
 		M.buckled.set_dir(M.dir)
 		
-	SSDispatcher.add_to_tracking(M)		//Eclipse edit: Add to dispatcher tracking.
+	SSdispatcher.add_to_tracking(M)		//Eclipse edit: Add to dispatcher tracking.
 	return TRUE
 
 /datum/spawnpoint/nosearch //for when we want people to start on the exact tile of the spawn landmark
@@ -199,7 +199,7 @@
 		//When spawning in cryo, you start off asleep for a few moments and wake up
 		M.Paralyse(2)
 		
-		SSDispatcher.add_to_tracking(M)		//Eclipse edit: Add to dispatcher tracking.
+		SSdispatcher.add_to_tracking(M)		//Eclipse edit: Add to dispatcher tracking.
 
 		//You can get yourself out of the cryopod, or it will auto-eject after one minute
 		spawn(600)
@@ -260,7 +260,7 @@
 
 		//Once you wake up, you can get yourself out of bed. I've made it real easy, just click basically anything
 		
-		SSDispatcher.add_to_tracking(M)		//Eclipse addition: Add to dispatcher tracking.
+		SSdispatcher.add_to_tracking(M)		//Eclipse addition: Add to dispatcher tracking.
 
 		return TRUE
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Closes #1487 as fixed.

Adds two measures to make sure latejoin players are counted by the dispatcher: A.) players should now be tracked as they enter the game, and B.) adds periodic updates to ensure players who might get missed by A are still counted.

This has been tested on a local server by latejoining in the aft cryo and the dormitories; all three times, it added the mob to the tracking list. Performance impact of the periodic updates appear to be minimal.

In addition, should I need to, I can now pull a player tracking dump without needing to pester Nestor to grab it from the server and send it to me.

## Changelog
:cl: EvilJackCarver
fix: Fixed a few edge cases with the dispatcher not tracking players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
