### PR TITLE
Fixes cruciforms annihilating non-humans

### DIFF
--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -84,7 +84,7 @@ var/list/disciples = list()
 	var/observation_points = 200
 	if(!wearer || active)
 		return
-	if(wearer.get_species() != SPECIES_HUMAN || is_carrion(wearer))
+	if(is_carrion(wearer)) //Eclipse edit - pls don't explode furries
 		if(wearer.get_species() == "Monkey")
 			observation_points /= 20
 		playsound(wearer.loc, 'sound/hallucinations/wail.ogg', 55, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Exactly what it says on the tin. 
Fixes - https://github.com/Eclipse-Station/NEV-Northern-Light/issues/1502

## Why It's Good For The Game

Fixes a rather critical bug

## Changelog
:cl:
fix: You can spawn with cruciform as non-human again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
