### PR TITLE
Ports 'Input Load' feature from ES13 SMES UI

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -138,6 +138,8 @@
 	return round(5.5*charge/(capacity ? capacity : 5e6))
 
 /obj/machinery/power/smes/proc/input_power(var/percentage)
+	// // // BEGIN ECLIPSE EDITS // // //
+	// Change input power to a variable we can track for use in the NanoUI element
 	input_used = target_load * (percentage/100)
 	input_used = between(0, input_used, target_load)
 	if(terminal && terminal.powernet)
@@ -148,6 +150,7 @@
 		else if(percentage)
 			inputting = 1
 		// else inputting = 0, as set in process()
+	// // // END ECLIPSE EDITS // // //
 
 /obj/machinery/power/smes/Process()
 	if(stat & BROKEN)	return
@@ -176,16 +179,14 @@
 
 	//outputting
 	if(output_attempt && (!output_pulsed && !output_cut) && powernet && charge)
-		output_used = min(charge/SMESRATE, output_level)		//limit output to that stored
+		output_used = min(charge/SMESRATE, output_level)		//limit output to that stored		//Eclipse edit - trim leading whitespace
 		charge -= output_used*SMESRATE		// reduce the storage (may be recovered in /restore() if excessive)
 		add_avail(output_used)				// add output to powernet (smes side)
 		outputting = 2
 	else if(!powernet || !charge)
 		outputting = 1
-		output_used = 0
 	else
 		outputting = 0
-		output_used = 0
 
 // called after all power processes are finished
 // restores charge level to smes if there was excess this ptick

--- a/nano/templates/smes_eclipse.tmpl
+++ b/nano/templates/smes_eclipse.tmpl
@@ -1,0 +1,110 @@
+{{if data.failTime}}
+<div class='notice'>
+	<b><h3>SYSTEM FAILURE</h3></b>
+	<i>I/O regulators malfunction detected! Waiting for system reboot...</i><br>
+	Automatic reboot in {{:data.failTime}} seconds...
+	{{:helper.link('Reboot Now', 'refresh', {'reboot' : 1})}}<br><br><br>
+</div>
+{{else}}
+<div class="item">
+	<div class="itemLabel">
+		Stored Capacity:
+	</div>
+	<div class="itemContent">
+		{{:helper.displayBar(data.storedCapacity, 0, 100, data.charging ? 'good' : 'average')}}
+		<div class="statusValue">
+			{{:helper.round(data.storedCapacity)}}%
+		</div>
+	</div>
+</div>
+
+<h3>Input Management</h3>
+<div class="item">
+	<div class="itemLabel">
+		Charge Mode:
+	</div>
+	<div class="itemContent">
+		{{:helper.link('Auto', 'refresh', {'cmode' : 1}, data.chargeMode ? 'selected' : null)}}{{:helper.link('Off', 'close', {'cmode' : 1}, data.chargeMode ? null : 'selected')}}
+		&nbsp;
+		{{if data.charging == 2}}
+			[<span class='good'>Charging</span>]
+		{{else data.charging == 1}}
+			[<span class='average'>Partially Charging</span>]
+		{{else}}
+			[<span class='bad'>Not Charging</span>]
+		{{/if}}
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Input Level:
+	</div>
+	<div class="itemContent">
+		{{:helper.displayBar(data.chargeLevel, 0, data.chargeMax)}}
+		<div style="clear: both; padding-top: 4px;">
+			{{:helper.link('MIN', null, {'input' : 'min'}, (data.chargeLevel > 0) ? null : 'disabled')}}
+			{{:helper.link('SET', null, {'input' : 'set'}, null)}}			
+			{{:helper.link('MAX', null, {'input' : 'max'}, (data.chargeLevel < data.chargeMax) ? null : 'disabled')}}
+			<div style="float: left; width: 100px; text-align: center;">&nbsp;{{:data.chargeLevel}} W&nbsp;</div>
+		</div>
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Input Load:
+	</div>
+	<div class="itemContent">
+		{{:helper.displayBar(data.inputLoad, 0, data.chargeMax, (data.inputLoad > data.outputLoad) ? 'good' : 'average')}}
+		<div class="statusValue">
+			{{:data.inputLoad}} W
+		</div>
+	</div>
+</div>
+
+<h3>Output Management</h3>
+<div class="item">
+	<div class="itemLabel">
+		Output Status:
+	</div>
+	<div class="itemContent">
+		{{:helper.link('Online', 'power', {'online' : 1}, data.outputOnline ? 'selected' : null)}}{{:helper.link('Offline', 'close', {'online' : 1}, data.outputOnline ? null : 'selected')}}
+		&nbsp;
+		{{if data.outputting == 2}}
+			[<span class='good'>Outputting</span>]
+		{{else data.outputting == 1}}
+			[<span class='average'>Disconnected or No Charge</span>]
+		{{else}}
+			[<span class='bad'>Not Outputting</span>]
+		{{/if}}
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Output Level:
+	</div>
+	<div class="itemContent">
+		{{:helper.displayBar(data.outputLevel, 0, data.outputMax)}}
+		<div style="clear: both; padding-top: 4px;">
+			{{:helper.link('MIN', null, {'output' : 'min'}, (data.outputLevel > 0) ? null : 'disabled')}}
+			{{:helper.link('SET', null, {'output' : 'set'}, null)}}			
+			{{:helper.link('MAX', null, {'output' : 'max'}, (data.outputLevel < data.outputMax) ? null : 'disabled')}}
+			<div style="float: left; width: 100px; text-align: center;">&nbsp;{{:data.outputLevel}} W&nbsp;</div>			
+		</div>
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Output Load:
+	</div>
+	<div class="itemContent">
+		{{:helper.displayBar(data.outputLoad, 0, data.outputMax, (data.outputLoad < data.outputLevel) ? 'good' : 'average')}}
+		<div class="statusValue">
+			{{:data.outputLoad}} W
+		</div>
+	</div>
+</div>
+{{/if}}


### PR DESCRIPTION
## About The Pull Request

Ports the 'Input Load' bar and number from older ES13 code.

This does not affect the RCon UI at all; that'll still show the input load at whatever it's set to. Another project for another day.

![image](https://user-images.githubusercontent.com/1784490/126071913-f0b8ab3d-09ca-4470-bd3f-599b5a2a7395.png)


## Why It's Good For The Game

Quality of life change, aimed at reducing confusion why the SMES might not be outputting at maximum if it's not charged enough to output at maximum.


## Changelog
:cl: EvilJackCarver
add: QoL: SMES units now have an 'Input Load' meter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
