### PR TITLE
Balancing tweaks to Benzin roaches

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/types/nitro.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/nitro.dm
@@ -4,8 +4,8 @@
 	icon = 'zzz_modular_eclipse/icons/mob/mob.dmi'
 	icon_state = "nitroroach"
 	turns_per_move = 4
-	maxHealth = 5
-	health = 5
+	maxHealth = 25		//On par with Jaeger roaches
+	health = 25
 	melee_damage_upper = 3
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/roachmeat/nitro
 	meat_amount = 3

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/nitro.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/nitro.dm
@@ -15,13 +15,29 @@
 
 /mob/living/carbon/superior_animal/roach/nitro/ex_act()
 	if(!exploded)
-		visible_message(SPAN_DANGER("\the [src] violently detonates!"))
-		death()
+		kerplode()
+		
+/mob/living/carbon/superior_animal/roach/nitro/bullet_act(obj/item/projectile/slug)
+	if(!exploded && slug.ignition_source)
+		kerplode()
+	else
+		. = ..()
+
+/mob/living/carbon/superior_animal/roach/nitro/proc/kerplode()
+	if(!exploded)
+		exploded = TRUE
+		visible_message(SPAN_DANGER("\the [src] violently explodes!"))
+		explosion(src.loc, -1, -1, 2, 3) //explosion weaker than a welding tank
+		gib()
+
+/mob/living/carbon/superior_animal/roach/nitro/attackby(obj/item/I)
+	if(isflamesource(I))
+		kerplode()
+	else
+		. = ..()
 
 /mob/living/carbon/superior_animal/roach/nitro/death()
 	. = ..()
 	if(src)
 		if(!exploded)
-			exploded = TRUE
-			explosion(src.loc, -1, -1, 2, 3) //explosion weaker than a welding tank
-
+			new /obj/effect/decal/cleanable/liquid_fuel(src.loc, 5, 1)		//Half the amount of a leaky welderfuel tank.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -83,6 +83,7 @@
 										//  have to be recreated multiple times
 
 	var/noshake = FALSE //Eclipse add
+	var/ignition_source = FALSE		//Eclipse add - see if the projectile is capable of detonating fuel tanks and nitro roaches.
 
 /obj/item/projectile/is_hot()
 	if (damage_types[BURN])

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -10,6 +10,7 @@
 	var/frequency = 1
 	hitscan = 1
 	invisibility = 101	//beam projectiles are invisible as they are rendered by the effect engine
+	ignition_source = TRUE		//Eclipse addition
 
 	muzzle_type = /obj/effect/projectile/laser/muzzle
 	tracer_type = /obj/effect/projectile/laser/tracer
@@ -106,6 +107,7 @@
 	damage_types = list(BURN = 0)
 	no_attack_log = 1
 	check_armour = ARMOR_ENERGY
+	ignition_source = FALSE		//Eclipse add.
 
 	muzzle_type = /obj/effect/projectile/laser_blue/muzzle
 	tracer_type = /obj/effect/projectile/laser_blue/tracer
@@ -125,6 +127,7 @@
 	damage_types = list(BURN = 0)
 	no_attack_log = 1
 	check_armour = ARMOR_ENERGY
+	ignition_source = FALSE		//Eclipse add
 
 /obj/item/projectile/beam/lastertag/red/on_hit(atom/target)
 	if(ishuman(target))

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -8,6 +8,7 @@
 	sharp = FALSE
 	hitsound_wall = "ric_sound"
 	var/mob_passthrough_check = 0
+	ignition_source = TRUE		//Eclipse add
 
 	muzzle_type = /obj/effect/projectile/bullet/muzzle
 

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -29,6 +29,7 @@ There are important things regarding this file:
 	embed = FALSE
 	sharp = FALSE
 	can_ricochet = FALSE
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/pistol/rubber
 	icon_state = "rubber"
@@ -38,6 +39,7 @@ There are important things regarding this file:
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/pistol/scrap
 	damage_types = list(BRUTE = 25)
@@ -64,6 +66,7 @@ There are important things regarding this file:
 	embed = FALSE
 	sharp = FALSE
 	can_ricochet = FALSE
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/srifle/hv
 	damage_types = list(BRUTE = 30)
@@ -78,6 +81,7 @@ There are important things regarding this file:
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/srifle/scrap
 	damage_types = list(BRUTE = 22)
@@ -115,6 +119,7 @@ There are important things regarding this file:
 	embed = FALSE
 	sharp = FALSE
 	can_ricochet = TRUE
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/clrifle/scrap
 	damage_types = list(BRUTE = 24)
@@ -135,6 +140,7 @@ There are important things regarding this file:
 	embed = FALSE
 	sharp = FALSE
 	can_ricochet = FALSE
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/lrifle/hv
 	damage_types = list(BRUTE = 30)
@@ -149,6 +155,7 @@ There are important things regarding this file:
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/lrifle/scrap
 	damage_types = list(BRUTE = 25)
@@ -168,6 +175,7 @@ There are important things regarding this file:
 	embed = FALSE
 	sharp = FALSE
 	can_ricochet = FALSE
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/magnum/hv
 	damage_types = list(BRUTE = 39)
@@ -182,6 +190,7 @@ There are important things regarding this file:
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/magnum/scrap
 	damage_types = list(BRUTE = 30)
@@ -260,10 +269,12 @@ There are important things regarding this file:
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/shotgun/beanbag/scrap
 	damage_types = list(BRUTE = 9)
 	agony = 55
+	ignition_source = TRUE//Eclipse add: Because it's handmade ammo, it isn't as good quality and thus will detonate fuel tanks and nitro roaches. Use proper ammo!
 
 /obj/item/projectile/bullet/shotgun/practice
 	name = "practice slug"
@@ -272,6 +283,7 @@ There are important things regarding this file:
 	armor_penetration = 0
 	embed = FALSE
 	knockback = 0
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/shotgun/incendiary
 	damage_types = list(BRUTE = 45)
@@ -308,6 +320,7 @@ There are important things regarding this file:
 	invisibility = 101
 	damage_types = list(BRUTE = 1)
 	embed = FALSE
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/bullet/cap
 	name = "cap"
@@ -315,3 +328,4 @@ There are important things regarding this file:
 	nodamage = TRUE
 	embed = FALSE
 	sharp = FALSE
+	ignition_source = FALSE		//Eclipse add.

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -5,6 +5,7 @@
 	check_armour = ARMOR_ENERGY
 	mob_hit_sound = list('sound/effects/gore/sear.ogg')
 	hitsound_wall = 'sound/weapons/guns/misc/laser_searwall.ogg'
+	ignition_source = TRUE		//Eclipse add.
 
 	heat = 100
 
@@ -19,6 +20,7 @@
 	var/flash_range = 0
 	var/brightness = 7
 	var/light_duration = 5
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/energy/flash/on_impact(var/atom/A)
 	var/turf/T = flash_range? src.loc : get_turf(A)
@@ -44,6 +46,7 @@
 	flash_range = 1
 	brightness = 9 //similar to a flare
 	light_duration = 200
+	ignition_source = TRUE		//Eclipse add - did you really think shooting a welderfuel tank with a flare gun was a good idea?
 
 /obj/item/projectile/energy/electrode
 	name = "electrode"
@@ -67,12 +70,14 @@
 	nodamage = 1
 	damage_types = list(CLONE = 0)
 	irradiate = 150
+	ignition_source = FALSE		//Eclipse add.
 
 
 /obj/item/projectile/energy/dart
 	name = "dart"
 	icon_state = "toxin"
 	damage_types = list(TOX = 20)
+	ignition_source = FALSE		//Eclipse add.
 
 
 /obj/item/projectile/energy/bolt
@@ -93,8 +98,10 @@
 	icon_state = "neurotoxin"
 	damage_types = list(TOX = 5)
 	weaken = 5
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/energy/phoron
 	name = "phoron bolt"
 	icon_state = "energy"
 	damage_types = list(TOX = 25)
+	ignition_source = FALSE		//Eclipse add.

--- a/code/modules/projectiles/projectile/fragment.dm
+++ b/code/modules/projectiles/projectile/fragment.dm
@@ -8,6 +8,7 @@
 	silenced = TRUE //embedding messages are still produced so it's kind of weird when enabled.
 	no_attack_log = 1
 	muzzle_type = null
+	ignition_source = FALSE		//Eclipse add. If it's that busted, it's probably far from the source of the muzzle and expended most of its energy.
 
 /obj/item/projectile/bullet/pellet/fragment/strong
 	damage_types = list(BRUTE = 15)

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -6,6 +6,7 @@
 	armor_penetration = 25
 	check_armour = ARMOR_ENERGY
 	damage_types = list(BURN = 33)
+	ignition_source = TRUE		//Eclipse add.
 
 
 	muzzle_type = /obj/effect/projectile/plasma/muzzle

--- a/code/modules/projectiles/projectile/projectilegrenades.dm
+++ b/code/modules/projectiles/projectile/projectilegrenades.dm
@@ -7,6 +7,7 @@
 	armor_penetration = 0
 	embed = FALSE
 	sharp = FALSE
+	ignition_source = FALSE		//Eclipse add - the rest are subtypes of bullet and do explode.
 
 /obj/item/projectile/bullet/grenade
 	name = "grenade shell"

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -4,6 +4,7 @@
 	damage_types = list(BURN = 0)
 	nodamage = TRUE
 	check_armour = ARMOR_ENERGY
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/ion/on_hit(atom/target)
 	empulse(target, 1, 1)
@@ -87,6 +88,7 @@
 	damage_types = list(TOX = 0)
 	nodamage = TRUE
 	check_armour = ARMOR_ENERGY
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/energy/floramut/on_hit(atom/target)
 	var/mob/living/M = target
@@ -119,6 +121,7 @@
 	damage_types = list(TOX = 0)
 	nodamage = TRUE
 	check_armour = ARMOR_ENERGY
+	ignition_source = FALSE		//Eclipse add.
 
 /obj/item/projectile/energy/florayield/on_hit(atom/target)
 	var/mob/M = target
@@ -147,6 +150,7 @@
 	embed = 0 // nope
 	nodamage = TRUE
 	muzzle_type = /obj/effect/projectile/bullet/muzzle
+	ignition_source = TRUE		//Eclipse add - fake guns are still guns
 
 
 /obj/item/projectile/flamer_lob
@@ -155,6 +159,7 @@
 	damage_types = list(BURN = 20)
 	check_armour = ARMOR_MELEE
 	var/life = 3
+	ignition_source = TRUE		//Eclipse add.
 
 
 /obj/item/projectile/flamer_lob/New()
@@ -176,4 +181,4 @@
 	desc = "Keep the change, ya filthy animal."
 	damage_types = list(BRUTE = 5)
 	embed = 0
-
+	ignition_source = FALSE		//Eclipse add - no more Heseil going boom today.

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -141,7 +141,7 @@
 	if(!..(user, 2))
 		return
 	if(modded)
-		to_chat(user, SPAN_WARNING("Fuel faucet is open, leaking the fuel!"))
+		to_chat(user, SPAN_WARNING("It is leaking fuel!"))
 	if(rig)
 		to_chat(user, SPAN_NOTICE("There is some kind of device rigged to the tank."))
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -193,15 +193,19 @@
 
 	return ..()
 
-
+// // // BEGIN ECLIPSE EDITS // // //
+// Welderfuel tanks will not explode if shot with rubber bullets, etc.
 /obj/structure/reagent_dispensers/fueltank/bullet_act(var/obj/item/projectile/Proj)
 	if(Proj.get_structure_damage())
 		if(istype(Proj.firer))
-			message_admins("[key_name_admin(Proj.firer)] shot fueltank at [loc.loc.name] ([loc.x],[loc.y],[loc.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[loc.x];Y=[loc.y];Z=[loc.z]'>JMP</a>).")
-			log_game("[key_name(Proj.firer)] shot fueltank at [loc.loc.name] ([loc.x],[loc.y],[loc.z]).")
-
-		if(!istype(Proj ,/obj/item/projectile/beam/lastertag) && !istype(Proj ,/obj/item/projectile/beam/practice) )
+			message_admins("[key_name_admin(Proj.firer)] shot fueltank at [loc.loc.name] ([loc.x],[loc.y],[loc.z]). Projectile was [Proj.ignition_source ? "" : "not"] an ignition source. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[loc.x];Y=[loc.y];Z=[loc.z]'>JMP</a>).")
+			log_game("[key_name(Proj.firer)] shot fueltank at [loc.loc.name] ([loc.x],[loc.y],[loc.z]). Projectile was [Proj.ignition_source ? "" : "not"] an ignition source.")
+		if(Proj.ignition_source)
 			explode()
+		else
+			if(!istype(Proj, /obj/item/projectile/beam) )		//Beam weaponry won't cause a leak. You're SOL for coins, though, those things are HEAVY compared to a bullet.
+				modded = TRUE
+// // // END ECLIPSE EDITS // // //
 
 /obj/structure/reagent_dispensers/fueltank/ex_act()
 	explode()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Benzins no longer explode from blunt-force trauma. In addition, certain bullet types won't cause them to explode. In order to compensate for this, their health has been increased from 5 to 25 (on par with Jäger roaches).

Welderfuel tanks also no longer explode from being shot by certain ammo types - they will leak instead.

![image](https://user-images.githubusercontent.com/1784490/128621933-55a25225-b8f9-40c6-81e7-f1be21bf3dca.png)


## Why It's Good For The Game

A roach should not explode because you went full Gordon Freeman on it.

## Changelog
:cl: EvilJackCarver
tweak: Added a variable to projectiles to determine if it will explode welderfuel tanks or Benzin roaches.
balance: Benzin roaches no longer explode from blunt-force trauma.
balance: Benzin roaches now leak welder fuel when killed.
balance: Benzin roaches now gib when exploded. You can now detonate Benzin roaches after their death if you so desire. (Why anyone would WANT to do that, is beyond me.)
balance: Buffed Benzin health up to 25 to counteract the above.
balance: Welderfuel tanks no longer explode if shot at by bullets that shouldn't explode them; they will instead leak.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
