### PR TITLE
Increases the view range from 8x8 to 11x11. Makes x2 distort mode default, settings save when applied.

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -52,7 +52,7 @@ var/game_id
 	mob = /mob/new_player
 	turf = /turf/space
 	area = /area/space
-	view = "15x15"
+	view = 11
 	cache_lifespan = 0	//stops player uploaded stuff from being kept in the rsc past the current session
 
 /world/proc/enable_debugger()

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1129,6 +1129,7 @@ window "mainwindow"
 		saved-params = "splitter"
 		right = "rpane"
 		is-vert = true
+		splitter = 75
 	elem "input"
 		type = INPUT
 		pos = 3,420
@@ -1179,10 +1180,12 @@ window "mapwindow"
 		size = 640x480
 		anchor1 = 0,0
 		anchor2 = 100,100
-		font-family = "Arial Rounded MT Bold,Arial Black,Arial,sans-serif"
-		font-size = 7
+		font-family = "serif"
+		font-size = 6
 		is-default = true
-		saved-params = "icon-size"
+		saved-params = "icon-size;zoom-mode"
+		zoom = 2
+		zoom-mode = distort
 		on-show = ".winset\"mainwindow.mainvsplit.left=mapwindow\""
 		on-hide = ".winset\"mainwindow.mainvsplit.left=\""
 	elem "lobbybrowser"
@@ -1432,3 +1435,4 @@ window "text_editor"
 		border = line
 		saved-params = ""
 		multi-line = true
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://user-images.githubusercontent.com/8602857/130340867-45879e9f-0fe6-4e84-8239-19dabb72046d.png)

Increases the view range from 8 to 11. By default the splitter is now 75/25 instead of 50/50. By default the scaling is x2 pixel perfect. Splitter settings and icon settings are saved across sessions. Map text (if this is even used) is no longer bad and blurry.

## Why It's Good For The Game

It's [CURRENT YEAR], we should have an interface that takes up the entire screen.

## Changelog
:cl: BurgerBB
tweak: Increases the view range from 8 to 11. By default the splitter is now 75/25 instead of 50/50. By default the scaling is x2 pixel perfect. Splitter settings and icon settings are saved across sessions.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
