### PR TITLE
Fixes welding fuel behaviour with regards to Z-levels

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -36,10 +36,27 @@
 		var/turf/simulated/target = get_step(src,d)
 		var/turf/simulated/origin = get_turf(src)
 		if(origin.CanPass(null, target, 0, 0) && target.CanPass(null, origin, 0, 0))
+			// // // BEGIN ECLIPSE EDITS // // //
+			//Liquid falling code.
+			if(istype(target, /turf/simulated/open))		//Begin this with an if-check for the redundancy.
+				if(amount < 10)
+					continue		//Not enough to leak over an edge.
+				var/iterations = 0
+				while(istype(target, /turf/simulated/open))
+					if(!GetBelow(target))		//No turf underneath this one. We'll enter nullspace if we continue - abort the proc
+						break
+					iterations++
+					target = GetBelow(target)
+					if(iterations >= 10)
+						break		//Can't find a turf below after ten retries.
+				if(istype(target, /turf/simulated/open))		//More redundancy.
+					continue		//We didn't find a suitable turf to spread to, so go to the next direction.
 			var/obj/effect/decal/cleanable/liquid_fuel/other_fuel = locate() in target
 			if(other_fuel)
 				other_fuel.amount += amount*0.25
 				if(!(other_fuel in exclude))
+					exclude += other_fuel		//Add the other fuel to the excluded spread turfs, so we don't stack the fuel.
+			// // // END ECLIPSE EDITS // // //
 					exclude += src
 					other_fuel.Spread(exclude)
 			else

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/nitro.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/nitro.dm
@@ -9,6 +9,8 @@
 	melee_damage_upper = 3
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/roachmeat/nitro
 	meat_amount = 3
+	var/leaked = FALSE
+	var/impending_explosion = FALSE
 
 	rarity_value = 40
 	var/exploded = FALSE
@@ -22,8 +24,16 @@
 		kerplode()
 	else
 		. = ..()
+	
+/mob/living/carbon/superior_animal/roach/nitro/fire_act()
+	if(!exploded && !impending_explosion)
+		impending_explosion = TRUE
+		spawn(rand(30,150))
+			kerplode()
+	. = ..()
 
 /mob/living/carbon/superior_animal/roach/nitro/proc/kerplode()
+	impending_explosion = TRUE
 	if(!exploded)
 		exploded = TRUE
 		visible_message(SPAN_DANGER("\the [src] violently explodes!"))
@@ -39,5 +49,6 @@
 /mob/living/carbon/superior_animal/roach/nitro/death()
 	. = ..()
 	if(src)
-		if(!exploded)
-			new /obj/effect/decal/cleanable/liquid_fuel(src.loc, 5, 1)		//Half the amount of a leaky welderfuel tank.
+		if(!exploded && !leaked)
+			new /obj/effect/decal/cleanable/liquid_fuel(src.loc, 50, 1)		//A welderfuel tank below 50 units makes the explosion above (with no flash), so we'll put 50 here to explain the higher flash range.
+			leaked = TRUE


### PR DESCRIPTION
## About The Pull Request

Fixes welding fuel behaviour when it spreads across an open space turf. Previously, it would spread to the open space turf, then fall. Now, it calculates where it would land and spreads there instead of directly on the open space turf.

Fixes an edge case where Benzins lit on fire wouldn't explode. Now, they're a bootleg grenade, with a timer between 3 and 15 seconds.

Fixes an edge case where Benzins could leak welding fuel more than once under certain circumstances.

Closes #1545 as fixed.

## Why It's Good For The Game

Fixes some bugs, and fixes some bugs.

## Changelog
:cl: EvilJackCarver
tweak: Partially refactored how welding fuel spreads, to account for Z-level travel.
fix: Fixed an issue where welding fuel would create a stack of puddles atop each other if they fell a Z-level.
fix: Fixed an edge case where a Benzin lit on fire would not explode. Now, a Benzin lit on fire will explode 3 to 15 seconds later.
fix: Fixed an edge case where a Benzin could leak welder fuel more than once.
balance: Increased the amount of welder fuel a defeated Benzin will leak. (Was 5, now 50.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
