### PR TITLE
Comments out periodic player-tracking updates.

### DIFF
--- a/code/controllers/subsystems/dispatcher.dm
+++ b/code/controllers/subsystems/dispatcher.dm
@@ -118,7 +118,8 @@ SUBSYSTEM_DEF(dispatcher)
 			log_debug("DISPATCHER: Initial flush completed.")
 		first_run = FALSE
 		return		//We're done with the initial flush.
-	
+
+/*		//Scheduled updates aren't really necessary; the "spawn at dorms, not in tracking" bit works fine.
 	//Periodic list maintenance.
 	if(!(times_fired % 150))	//Every 5 minutes or so, update the tracking data.
 		if(update_in_progress || flush_in_progress)
@@ -172,6 +173,7 @@ SUBSYSTEM_DEF(dispatcher)
 
 		if(DEBUGLEVEL_VERBOSE <= debug_level)
 			log_debug("DISPATCHER: Finished scheduled update.")
+*/
 
 /datum/controller/subsystem/dispatcher/Recover()
 	flush_tracking()


### PR DESCRIPTION
## About The Pull Request

Comments out redundant periodic updates to the player-tracking part of the dispatcher.

## Why It's Good For The Game
The periodic updates were originally intended as a fallback method to ensure players who spawned in the dorms were added to the tracking. Right now, it's just redundant code that occasionally adds in bluespace technicians and admeme spawns to the tracking lists whether or not the admemes wanted them on the tracking lists, which isn't desirable.

## Changelog
:cl: EvilJackCarver
del: The NTDAD player tracking system will no longer periodically add everyone who isn't on the list to the lists.
fix: Fixes an issue where bluespace technicians would show up in the NTDAD player tracking system.
/:cl:
