### PR TITLE
Stonks and Shields

### DIFF
--- a/code/controllers/subsystems/economy.dm
+++ b/code/controllers/subsystems/economy.dm
@@ -181,6 +181,8 @@ SUBSYSTEM_DEF(economy)
 		for (var/datum/computer_file/report/crew_record/R in department.pending_wages)
 			var/paid = FALSE
 			//Get the crewman's account that we'll pay to
+			if(R.get_status() != "Active")
+				continue
 			var/crew_account_num = R.get_account()
 			var/amount = department.pending_wages[R]
 			paid = transfer_funds(department.account_number, crew_account_num, "Payroll", "NEV Northern Light payroll system", amount)

--- a/code/game/jobs/department.dm
+++ b/code/game/jobs/department.dm
@@ -61,7 +61,7 @@
 	In future, we will implement largescale missions and research contracts to earn money, and then set it
 	to a much lower starting value
 	*/
-	account_initial_balance = 2000000
+	account_initial_balance = 100000
 	funding_type = FUNDING_NONE
 
 
@@ -82,7 +82,8 @@
 /datum/department/civilian
 	name = "NEV Northern Light Civic"
 	id = DEPARTMENT_CIVILIAN
-	account_budget = 2000
+	account_initial_balance = 2000
+	funding_type = FUNDING_NONE
 	//Now for the club
 
 
@@ -93,20 +94,21 @@
 /datum/department/moebius_medical
 	name = "Lazarus Foundation: Medical Division"
 	id = DEPARTMENT_MEDICAL
-	funding_type = FUNDING_EXTERNAL
-	funding_source = "NanoTrasen."
+	account_initial_balance = 5000
+	funding_type = FUNDING_INTERNAL
+	funding_source = "DEPARTMENT_SCIENCE"
 
 /datum/department/moebius_research
 	name = "Lazarus Foundation: Research Division"
 	id = DEPARTMENT_SCIENCE
-	account_budget = 5000 //For buying materials and components and things of scientific value
-	funding_type = FUNDING_EXTERNAL
+	account_initial_balance = 10000 //For buying materials and components and things of scientific value
+	funding_type = FUNDING_NONE
 	funding_source = "NanoTrasen."
 
 /datum/department/church
 	name = "Children of Mekhane"
 	id = DEPARTMENT_CHURCH
-	account_budget = 4500 //each Neotheo has a wage of 900, this is enough to pay 5 paychecks before needing more cash
+	account_initial_balance = 4500 //each Neotheo has a wage of 900, this is enough to pay 5 paychecks before needing more cash
 	funding_type = FUNDING_NONE //The church on eris has no external funding. This further reinforces the theory that everyone on the CEV Eris is a reject of their factions
 	funding_source = "Church of NeoTheology"
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -235,7 +235,7 @@
 	total_positions = 6
 	spawn_positions = 6
 	supervisors = "the Aegis Commander"
-	//alt_titles = list("Aegis Junior Operative")
+	alt_titles = list("Aegis Cadet")
 	selection_color = "#a7bbc6"
 	wage = WAGE_LABOUR_HAZARD
 	also_known_languages = list(LANGUAGE_CYRILLIC = 25, LANGUAGE_SERBIAN = 25, LANGUAGE_NEOHONGO = 45, LANGUAGE_GERMAN = 10)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -289,7 +289,7 @@
 	var/list/occupant_organs
 	if(istype(H))
 		occupant_organs = H.organs | H.internal_organs
-		
+
 	//Drop all items into the pod.
 	//// Local pod code
 	for(var/obj/item/W in occupant)
@@ -362,6 +362,16 @@
 
 	// This removes them from player tracking
 	SSdispatcher.remove_from_tracking(occupant)		//Eclipse edit
+	
+	// // // BEGIN ECLIPSE EDITS // // //
+	//Set their status to cryosleep in their records, so it doesn't drain their department's account.
+	var/datum/computer_file/report/crew_record/record = get_crewmember_record(H.name)
+	if(record)
+		record.set_status("Cryostasis")
+		log_debug("Set [H.name] to status \"Cryostasis\" in the crew records.")
+	else
+		log_debug("Unable to set [H.name] to Cryostasis in the records computer: Record does not exist.")
+	// // // END ECLIPSE EDITS // // //
 	
 	// This despawn is not a gib() in this sense, it is used to remove objectives tied on these despawned mobs in cryos
 	occupant.despawn()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -195,7 +195,7 @@
 	on_store_name = "Robotic Storage Oversight"
 	on_enter_occupant_message = "The storage unit broadcasts a sleep signal to you. Your systems start to shut down, and you enter low-power mode."
 	allow_occupant_types = list(/mob/living/silicon/robot)
-	disallow_occupant_types = list(/mob/living/silicon/robot/drone)
+	disallow_occupant_types = list()
 	applies_stasis = 0
 
 /obj/machinery/cryopod/New()
@@ -289,7 +289,7 @@
 	var/list/occupant_organs
 	if(istype(H))
 		occupant_organs = H.organs | H.internal_organs
-
+		
 	//Drop all items into the pod.
 	//// Local pod code
 	for(var/obj/item/W in occupant)

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_EMPTY(all_crew_records)
 GLOBAL_LIST_INIT(blood_types, list("A-", "A+", "B-", "B+", "AB-", "AB+", "O-", "O+"))
-GLOBAL_LIST_INIT(physical_statuses, list("Active", "Disabled", "SSD", "Deceased", "MIA"))
+GLOBAL_LIST_INIT(physical_statuses, list("Active", "Cryostasis", "SSD", "Deceased", "MIA", "Off Duty"))
 GLOBAL_VAR_INIT(default_physical_status, "Active")
 GLOBAL_LIST_INIT(security_statuses, list("None", "Released", "Parolled", "Incarcerated", "*Arrest*"))
 GLOBAL_VAR_INIT(default_security_status, "None")

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -204,7 +204,7 @@ FIELD_SHORT("Department", department, null, access_change_ids)
 FIELD_SHORT("Job", job, null, access_change_ids)
 FIELD_LIST("Sex", sex, record_genders(), null, access_change_ids)
 FIELD_NUM("Age", age, null, access_change_ids)
-FIELD_LIST_EDIT("Status", status, GLOB.physical_statuses, null, access_moebius)
+FIELD_LIST_EDIT("Status", status, GLOB.physical_statuses, null, access_heads)
 
 FIELD_SHORT("Species",species, null, access_change_ids)
 FIELD_SHORT("Email",email, null, access_change_ids)

--- a/code/modules/shield_generators/modes.dm
+++ b/code/modules/shield_generators/modes.dm
@@ -12,66 +12,66 @@
 	mode_name = "Hyperkinetic Projectiles"
 	mode_desc = "This mode blocks various fast moving physical objects, such as bullets, blunt weapons, meteors and other."
 	mode_flag = MODEFLAG_HYPERKINETIC
-	multiplier = 1.2
+	multiplier = 2.0
 
 /datum/shield_mode/photonic
 	mode_name = "Photonic Dispersion"
 	mode_desc = "This mode blocks majority of light. This includes beam weaponry and most of the visible light spectrum."
 	mode_flag = MODEFLAG_PHOTONIC
-	multiplier = 1.3
+	multiplier = 2.6
 
 /datum/shield_mode/humanoids
 	mode_name = "Humanoid Lifeforms"
 	mode_desc = "This mode blocks various humanoid lifeforms. Does not affect fully synthetic humanoids."
 	mode_flag = MODEFLAG_HUMANOIDS
-	multiplier = 1.5
+	multiplier = 3.0
 
 /datum/shield_mode/silicon
 	mode_name = "Silicon Lifeforms"
 	mode_desc = "This mode blocks various silicon based lifeforms."
 	mode_flag = MODEFLAG_ANORGANIC
-	multiplier = 1.5
+	multiplier = 3.0
 
 /datum/shield_mode/mobs
 	mode_name = "Unknown Lifeforms"
 	mode_desc = "This mode blocks various other non-humanoid and non-silicon lifeforms. Typical uses include blocking carps."
 	mode_flag = MODEFLAG_NONHUMANS
-	multiplier = 1.5
+	multiplier = 3.0
 
 /datum/shield_mode/atmosphere
 	mode_name = "Atmospheric Containment"
 	mode_desc = "This mode blocks air flow and acts as atmosphere containment."
 	mode_flag = MODEFLAG_ATMOSPHERIC
-	multiplier = 1.3
+	multiplier = 3
 
 /datum/shield_mode/hull
 	mode_name = "Hull Shielding"
 	mode_desc = "This mode recalibrates the field to cover surface of the installation instead of projecting a bubble shaped field."
 	mode_flag = MODEFLAG_HULL
-	multiplier = 1
+	multiplier = 2
 
 /datum/shield_mode/adaptive
 	mode_name = "Adaptive Field Harmonics"
 	mode_desc = "This mode modulates the shield harmonic frequencies, allowing the field to adapt to various damage types."
 	mode_flag = MODEFLAG_MODULATE
-	multiplier = 2
+	multiplier = 4
 
 /datum/shield_mode/bypass
 	mode_name = "Diffuser Bypass"
 	mode_desc = "This mode disables the built-in safeties which allows the generator to counter effect of various shield diffusers. This tends to create a very large strain on the generator."
 	mode_flag = MODEFLAG_BYPASS
-	multiplier = 3
+	multiplier = 6
 	hacked_only = 1
 
 /datum/shield_mode/overcharge
 	mode_name = "Field Overcharge"
 	mode_desc = "This mode polarises the field, causing damage on contact. Very harmful to all life."
 	mode_flag = MODEFLAG_OVERCHARGE
-	multiplier = 3
+	multiplier = 6
 	hacked_only = 1
 
 /datum/shield_mode/multiz
 	mode_name = "Multi-Dimensional Field Warp"
 	mode_desc = "Recalibrates the field projection array to increase the vertical height of the field, allowing it's usage on multi-deck stations or ships."
 	mode_flag = MODEFLAG_MULTIZ
-	multiplier = 1
+	multiplier = 2.0

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -46928,9 +46928,6 @@
 /turf/simulated/floor/carpet/blucarpet,
 /area/eris/command/fo)
 "ccS" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
 /obj/machinery/camera/network/fist_section{
 	dir = 8
 	},
@@ -47136,9 +47133,11 @@
 /turf/simulated/floor/carpet/blucarpet,
 /area/eris/command/fo)
 "cdt" = (
-/obj/structure/bed/chair/wood,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/bed/chair/wood{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/eris/command/fo)
@@ -47147,7 +47146,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/account_database{
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -47311,6 +47310,9 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/item/pen,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/eris/command/fo)
 "cdS" = (
@@ -59087,10 +59089,10 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck3starboard)
 "cEF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/hologram/holopad,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/eris/command/fo)
 "cEG" = (
@@ -110363,6 +110365,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
+"xTx" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/turf/simulated/floor/carpet/blucarpet,
+/area/eris/command/fo)
 "xUg" = (
 /turf/simulated/wall/r_wall,
 /area/eris/crew_quarters/sleep_female/toilet_female)
@@ -212899,7 +212905,7 @@ bwr
 bwI
 caS
 cbz
-ccl
+xTx
 cEF
 cdt
 cdR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #1561 :
- Adds accounts database terminal to personnel office
- Adds check in payroll for crew status, only crew set to "active" in crew records will get paid
- <s>I attempted to  write code to automatically update the status of a mob in "Crew Records" to "Cryostasis" when their mob is despawned in cryopod.dm, but was unable to get it working. Currently workaround solution is that an active head will need to set crew who've gone to cryo, died, or otherwise should not be paid, to a status other than Active.</s> Thanks to EvilJackCarver for figuring out the automation problem!

Adds two new statuses, "Cryostasis" and "Off Duty" for heads to more finely adjust activity.
- "Cryostasis" is for crew who have left the round
- "Off Duty" is for crew on a leave of some kind, whether voluntary or not. 
- Can add new statuses as the need arises,
- TODO: <s>make Cryopods automatically set status, and</s> in future, add "Punch-clocks" for crew to set themselves on/off duty

Restricted ship economy:
As the ship is cut off from home, resources are becoming scarcer, The crew will need to work harder to make a profit, as the unlimited pools of credits that once supplied this voyage dry up.
- Removed Lazarus External funding, 
- Medical now receives budget from Research, 
- Removed ship funding from Bar.
- Reduced ship account from 2,000,000c to 100,000c

Adds "Aegis Cadet" alt title
- Aegis is currently the only department lacking an "intern" role where that role would make sense. 

Removes restriction on drones entering robotic storage.. again?
- I swear I fixed this one already but it was showing up unchanged on my end again

Increased power cost on Shield systems
- The shields systems currently provide far too much protection for far too little cost, and their existence completely neutralizes over half a dozen separate events that can happen to the ship. This change greatly increases the power draw the shields need to  stay running, Making running advanced shield options like photonic dispersion or atmospheric containment options that are used in emergencies, and for limited times, instead of options that are just flicked on and forgotten about.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your Pull Request fixes an issue, please write "Fixes #1234" or "Closes #5678" so the issue automatically closes when the PR is merged. For more information, see Contributing.MD for further information. --->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Crew will now be automatically set to "Cryostasis" status in Crew records on despawn in Cryo, and will not be paid
add: Added "Aegis Cadet" as Operative alt title
add: Added new statuses in "Crew Records"
tweak: tweaked payroll, only crew listed "Active" in crew records get paid.
tweak: Crew Records now requires heads access to update Crew status manually
balance: rebalanced economy and ship accounts 
balance: rebalanced power cost of Shields
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
