### PR TITLE
CEV Erida - SMES Parts Box

### DIFF
--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -80090,6 +80090,24 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/eris/hallway/main/section2)
+"oJF" = (
+/obj/structure/catwalk,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/closet/crate,
+/obj/item/stock_parts/smes_coil,
+/obj/item/stock_parts/smes_coil,
+/obj/item/stock_parts/smes_coil/super_capacity,
+/obj/item/stock_parts/smes_coil/super_capacity,
+/obj/item/stock_parts/smes_coil/super_io,
+/obj/item/stock_parts/smes_coil/super_io,
+/obj/item/electronics/circuitboard/smes,
+/obj/item/electronics/circuitboard/smes,
+/turf/simulated/floor/plating/under,
+/area/eris/engineering/engine_room)
 "rok" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
@@ -136170,7 +136188,7 @@ ccW
 ciK
 clV
 cnz
-cnz
+oJF
 cqa
 dDc
 dDf


### PR DESCRIPTION
## About The Pull Request
![image](https://user-images.githubusercontent.com/31829017/150422831-fcc61735-5488-4651-8e8a-a6abfbd0ee30.png)
puts a SMES coil box next to the SMESes
## Why It's Good For The Game
power grid funnies
## Changelog
:cl:
add: The CEV Erida now has a SMES coil box, like the Eris did. It's just tucked into a corner of the SMES room.
/:cl: