### PR TITLE
More spiders in dungeon / Less window

### DIFF
--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -79258,6 +79258,11 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/erida/hallway/side/docks)
+"hlD" = (
+/obj/structure/catwalk,
+/obj/spawner/mob/spiders/cluster,
+/turf/simulated/floor/plating/under,
+/area/erida/maintenance/starboardsection2deck1)
 "hCi" = (
 /obj/structure/cyberplant,
 /obj/structure/extinguisher_cabinet{
@@ -79683,6 +79688,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/erida/maintenance/sciweapondeck)
+"rPb" = (
+/obj/spawner/mob/spiders/cluster,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/erida/maintenance/starboardsection2deck1)
 "szA" = (
 /obj/structure/sign/double/barsign,
 /turf/simulated/wall/r_wall,
@@ -164379,10 +164388,10 @@ aRo
 aVD
 aAE
 aAE
+aAE
 aWk
 aWk
-aWk
-aWk
+aAE
 aAE
 aAE
 bmC
@@ -164985,7 +164994,7 @@ aMk
 doA
 aRF
 dra
-aRF
+rPb
 drl
 drn
 aYF
@@ -165442,7 +165451,7 @@ dqV
 dqZ
 drc
 drg
-aVH
+hlD
 aYF
 drn
 bfO


### PR DESCRIPTION
## About The Pull Request

I've added two extra spider cluster spawns aswell as decreasing the size of the windows in the room to prevent mice-spawn from distracting the entire nest as easily. 

Before: 
![image](https://user-images.githubusercontent.com/34557989/154812999-b9123377-5bca-469c-a17a-a41e3aef2c3a.png)

After: 
![image](https://user-images.githubusercontent.com/34557989/154813007-0b085cab-cbcf-48dc-a2b1-26a67850480c.png)

## Why It's Good For The Game

Will provide a more difficult challenge for the loot inside the room, currently you get way too good loot for a challenge that is negligible due to lack of numbers and/or the presence of mice in the adjacent maint tunnel

## Changelog
:cl:
add: Added new spider cluster spawns
tweak: tweaked the maint window size
/:cl:
