### PR TITLE
Fix rad storm weather event visuals

### DIFF
--- a/code/game/gamemodes/events/weather/rad_storm.dm
+++ b/code/game/gamemodes/events/weather/rad_storm.dm
@@ -21,6 +21,6 @@
 	/area/shuttle/escape_pod5, /area/shuttle/specops/centcom, /area/shuttle/mercenary, /area/shuttle/administration, /area/eris/maintenance, \
 	/area/eris/crew_quarters/sleep/cryo, /area/eris/security/disposal, /area/eris/security/maintpost, /area/eris/rnd/anomalisolone, \
 	/area/eris/rnd/anomalisoltwo, /area/eris/rnd/anomalisolthree, /area/eris/rnd/server, /area/deepmaint, \
-	/area/outpost/blacksite/small, /area/outpost/blacksite/medium, /area/outpost/blacksite/large)
+	/area/outpost/blacksite/small, /area/outpost/blacksite/medium, /area/outpost/blacksite/large, /area/erida/maintenance)
 
 	immunity_type = "rad"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For some odd reason, the weather event for the rad storm uses a different check than the actual radiation check does. This does not fix that. This adds the "erida" maints area (and therefore subtypes) to the list it checks, protecting maintenance from the purely visual effects of the weather event. Please someone fix this properly some day so I don't have to learn how to do it myself.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your Pull Request fixes an issue, please write "Fixes #1234" or "Closes #5678" so the issue automatically closes when the PR is merged. For more information, see Contributing.MD for further information. --->

## Why It's Good For The Game
Misleading visuals.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Maintenance on the Erida will no longer falsely appear to be irradiated during radiation events.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
