### PR TITLE
Removes errant space tile in maints

### DIFF
--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -15717,10 +15717,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/neotheology/chapelritualroom)
-"aLC" = (
-/obj/structure/low_wall,
-/turf/simulated/floor/plating,
-/area/space)
 "aLD" = (
 /obj/machinery/button/windowtint{
 	pixel_y = -28
@@ -92356,7 +92352,7 @@ bbA
 cjl
 cjC
 bbr
-aLC
+aMx
 aMx
 bbr
 adb

--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -951,7 +951,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating/under,
-/area/space)
+/area/erida/maintenance/portsection2deck3)
 "acs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
@@ -79682,16 +79682,16 @@
 /obj/machinery/telecomms/server/presets/common,
 /turf/simulated/floor/bluegrid,
 /area/eris/command/tcommsat/chamber)
+"rPb" = (
+/obj/spawner/mob/spiders/cluster,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/erida/maintenance/starboardsection2deck1)
 "spc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/erida/maintenance/sciweapondeck)
-"rPb" = (
-/obj/spawner/mob/spiders/cluster,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/erida/maintenance/starboardsection2deck1)
 "szA" = (
 /obj/structure/sign/double/barsign,
 /turf/simulated/wall/r_wall,

--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -23940,7 +23940,7 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/space)
+/area/eris/maintenance/section3deck4starboard)
 "bfr" = (
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/armory)
@@ -79459,6 +79459,7 @@
 "lHc" = (
 /obj/structure/catwalk,
 /obj/machinery/holomap{
+	dir = 8;
 	pixel_x = 32
 	},
 /turf/simulated/floor/plating/under,
@@ -134473,7 +134474,7 @@ aKD
 dtV
 aZT
 axH
-aab
+aaM
 aav
 aav
 aav
@@ -139489,7 +139490,7 @@ aIz
 dtV
 aZT
 axH
-aab
+aaM
 aav
 aav
 aav


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This has been annoying me forever. Swaps it off of space to the actual maintenance area, probably has a dozen other ramifications. Edit: I did more, and hopefully fixed that AGRAVATING goddamn holomap by the mining shuttle that keeps slurping me into it every time I go by.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your Pull Request fixes an issue, please write "Fixes #1234" or "Closes #5678" so the issue automatically closes when the PR is merged. For more information, see Contributing.MD for further information. --->

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/29469766/161350823-d1e60afd-c507-404d-84b4-885b8798e12f.png)
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Removed space area from maintenance, ridding us of a maintenance shield.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
