### PR TITLE
Adds options to regenerate player icons to VV dropdown menu

### DIFF
--- a/code/modules/admin/view_variables/helpers.dm
+++ b/code/modules/admin/view_variables/helpers.dm
@@ -67,7 +67,10 @@
 		<option value='?_src_=vars;makerobot=\ref[src]'>Make cyborg</option>
 		<option value='?_src_=vars;makemonkey=\ref[src]'>Make monkey</option>
 		<option value='?_src_=vars;makeslime=\ref[src]'>Make slime</option>
+		<option value='?_src_=vars;regenmarkings=\ref[src]'>Regenerate markings</option>
+		<option value='?_src_=vars;regenerateiconsfully=\ref[src]'>Regenerate icons (full)</option>
 	"}
+	//Eclipse edit: Adds in 'regen markings' to fix them disappearing when cloning.
 
 /turf/get_view_variables_options()
 	return ..() + {"

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -321,6 +321,44 @@
 			to_chat(usr, "Set species of [H] to [H.species].")
 		else
 			to_chat(usr, "Failed! Something went wrong.")
+		
+	// // // BEGIN ECLIPSE EDITS // // //
+	// Marking fix procs for post-cloning.
+	else if(href_list["regenmarkings"])
+		if(!check_rights(R_DEBUG|R_ADMIN|R_MOD))
+			return
+		
+		//check the mob exists in the first place
+		var/mob/living/carbon/human/H = locate(href_list["regenmarkings"])
+		if(!H)
+			to_chat(usr, "Unable to regenerate markings: Mob does not exist or is non-human.")
+			return
+		
+		//check that the mob has markings
+		if(!H.dna.body_markings)
+			//If we don't have any markings, we only soft-fail - there may be an edge case where we want to regenerate them anyway.
+			if(alert("This mob has no markings to generate. Regenerate markings anyway?",,"Confirm","Abort") != "Confirm")
+				to_chat(usr, "Unable to generate markings: No markings to regenerate; override prompt aborted by user.")
+				return
+		
+		//Outside of the sanity checks, everything else is fairly simple. We just gotta
+		H.body_markings = H.dna.body_markings.Copy()		// and then we just call
+		H.update_icons()		//and that should be it.
+	
+	//Fully regenerate icons via calling the UpdateAppearance proc.
+	else if(href_list["regenerateiconsfully"])
+		if(!check_rights(R_DEBUG|R_ADMIN|R_MOD))
+			return
+		
+		//Once again, we start by seeing if the mob exists in the first place...
+		var/mob/living/carbon/human/H = locate(href_list["regenerateiconsfully"])
+		if(!H)
+			to_chat(usr, "Unable to regenerate icons: Mob does not exist or is non-human.")
+			return
+			
+		//And we call a proc that literally does it all for us.
+		H.UpdateAppearance()
+	// // // END ECLIPSE EDITS // // //
 
 	else if(href_list["addlanguage"])
 		if(!check_rights(R_FUN))


### PR DESCRIPTION
## About The Pull Request

Adds in administrative tools to fix players' markings, e.g. if they get cloned. 

The reason this is not automatic is to avoid a potential edge case where someone who is missing a limb during or after cloning (e.g. their head was gone, they got thrown in the basin, their head is no longer gone) who then has their markings regenerated could then have an errant marking visible on a missing limb.

### This pull request has only been build-tested, as I can't feasibly test it solo.

## Why It's Good For The Game

Currently, if I want to fix someone's markings after they get cloned, I either have to call a proc that does a lot more than just copies over their markings, or I have to raise the metaphorical mollyguard on the SDQL console and manually copy their sprite markings over from their `dna` datums to their mob variables.

Also adds a direct button to call the proc that does a lot more than just copy over their markings.

## Changelog
:cl: EvilJackCarver
admin: Adds in admin tools to fix players' markings. Access it in the VV dropdown.
admin: Adds in admin tools to completely regenerate players' sprites more fully than the Regnerate Icons dropdown does.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
