### PR TITLE
Adds ", lockers," to the multitool description

### DIFF
--- a/code/game/objects/items/weapons/tools/multitool.dm
+++ b/code/game/objects/items/weapons/tools/multitool.dm
@@ -6,7 +6,7 @@
 
 /obj/item/tool/multitool
 	name = "multitool"
-	desc = "Used for pulsing wires to test which to cut. You can use this on airlocks or APCs to try to hack them."
+	desc = "Used for pulsing wires to test which to cut. You can use this on airlocks, lockers, or APCs to try to hack them."
 	icon_state = "multitool"
 	flags = CONDUCT
 	force = WEAPON_FORCE_HARMLESS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title is a meme but the point is, multitools can pulse lockers to open them, it'd be good to make it visible that they can do such
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your Pull Request fixes an issue, please write "Fixes #1234" or "Closes #5678" so the issue automatically closes when the PR is merged. For more information, see Contributing.MD for further information. --->

## Why It's Good For The Game
Get players interacting with a not-entirely-known feature
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Multitools now show in their examine text that they can hack open lockers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
