### PR TITLE
Shield overheat mechanics

### DIFF
--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -81,6 +81,21 @@
 	var/list/tendrils = list()
 	var/list/tendril_dirs = list(NORTH, EAST, WEST)
 	var/tendrils_deployed = FALSE				// Whether the dummy capacitors are currently extended
+	
+	// Eclipse added vars
+	var/itt = T0C + 20		//Temperature of the unit. "Internal Turbine Temperature", after the dial on aircraft.
+	var/egt = T0C + 20		//Exhaust gas temperature. Used only for metering, really.
+	var/temperature_multiplier = 1	//Temperature-based power usage multiplier.
+	var/coefficient_of_performance = 99.93		//90% means that 10% of power is wasted as heat.
+	
+	var/threshold_cold = T0C + 10		//Used only for NanoUI formatting.
+	var/threshold_normal = T0C + 90		//Used only for NanoUI formatting.
+	var/threshold_critical = T0C + 110	//Used for NanoUI formatting and radio warnings.
+	var/threshold_high_temperature_cutout = T0C + 125		//Automatic E-stop if the shield generator hits this point.
+	var/threshold_alarm = FALSE		//Have we played the overheat warning over the radio?
+	var/threshold_shutdown_alarm = FALSE		//Did we shut down due to overheating?
+	
+	var/obj/item/device/radio/radio
 
 
 /obj/machinery/power/shield_generator/update_icon()
@@ -110,6 +125,9 @@
 	. = ..()
 	connect_to_network()
 	wires = new(src)
+	
+	radio = new /obj/item/device/radio{channels=list("Engineering")}(src)
+	assign_uid()
 
 	//Add all allowed modes to our mode list for users to select
 	mode_list = list()
@@ -124,6 +142,12 @@
 
 	// Link to Eris object on the overmap
 	linked_ship = (locate(/obj/effect/overmap/ship/eris) in GLOB.ships)
+	
+	// // // BEGIN ECLIPSE EDITS // // //
+	//Set our temperature to that of the environment, in case it isn't exactly 20 Celsius.
+	var/datum/gas_mixture/environment = loc.return_air()
+	itt = environment.temperature
+	// // // END ECLIPSE EDITS // // //
 
 /obj/machinery/power/shield_generator/Destroy()
 	toggle_tendrils(FALSE)
@@ -242,6 +266,56 @@
 	upkeep_power_usage = 0
 	power_usage = 0
 
+	// // // BEGIN ECLIPSE EDITS // // //
+	// Heat handling.
+	
+	//First, we need to see if we're on a valid turf.
+	var/turf/L = loc
+	var/datum/gas_mixture/environment
+	var/_safety = TRUE		//If this is false, we're not on a valid turf.
+	var/_working = TRUE
+	
+	if(offline_for || !(running == SHIELD_RUNNING) || emergency_shutdown)		//We aren't acively working
+		_working = FALSE
+	
+	//Some simple sanity checking.
+	if(isnull(L))		//If we're null, this isn't going to do anything anyway.
+		log_debug("Shield generator (process): Turf is null.")
+		_safety = FALSE
+	if(!istype(L))		//How are we in a box?
+		log_debug("Shield generator (process): Turf is invalid.")
+		_safety = FALSE
+	
+	if(_safety)
+		environment = L.return_air()
+		itt = environment.temperature
+		temperature_multiplier = clamp((T0C + 20)/(itt+10), 1, 4)		//If the room is super cold, the equipment is going to use more power because higher oil viscosity or whatever
+		
+		//we'll put out heat later, after we calculate energy usage.
+		
+	//Overheat code.
+	if((itt < threshold_critical) && threshold_alarm)	//Overheat alarm sounded, but we're cooled down.
+		if(threshold_alarm < 6)		//Give us a few Process() cycles for hysteresis, to avoid it warning us repeatedly if we're right on the edge.
+			threshold_alarm++
+		else		//We've been under the overheat threshold for 10 seconds, we can reset the alarm now.
+			if(!threshold_shutdown_alarm)		//If we caught it before the system cut off, then we announce we're cool enough.
+				radio.autosay("Shield generator returning to safe operating temperatures.", "Shield Generator monitor", "Engineering")
+				threshold_alarm = FALSE
+	
+	if(itt > threshold_critical)	//we're overheating.
+		if(!threshold_alarm)		//alarm hasn't sounded.
+			radio.autosay("WARNING: Shield generator temperature very high. Recommend reducing load immediately to return shield generator to normal operating temperatures and avoid a possible automatic emergency stop. Any internal damages caused by overheating are NOT covered by your manufacturer's warranty.", "Shield Generator monitor", "Engineering")
+		threshold_alarm = TRUE		//We explicitly set it true here to reset the hysteresis cycles above.
+	if(itt > threshold_high_temperature_cutout)		//critical overheat, shut everything down.
+		if(!threshold_shutdown_alarm)		//Alarm has not sounded, so we'll assume everything is still on. Shut it all down.
+			radio.autosay("WARNING: Shield generator temperature critical. Shield generator shutting down immediately to prevent internal damage.", "Shield Generator monitor", "Engineering")
+			threshold_shutdown_alarm = TRUE
+			emergency_shutdown = TRUE
+			offline_for = 300
+			shutdown_field()
+			input_cap = 1
+	// // // END ECLIPSE EDITS // // //
+
 	if (!anchored)
 		return
 	if(offline_for)
@@ -262,7 +336,7 @@
 
 	update_upkeep_star_multiplier() // Update shield upkeep depending on proximity to the star at the center of the overmap
 
-	upkeep_power_usage = round((field_segments.len - damaged_segments.len) * ENERGY_UPKEEP_PER_TILE * upkeep_multiplier * upkeep_star_multiplier)
+	upkeep_power_usage = round((field_segments.len - damaged_segments.len) * ENERGY_UPKEEP_PER_TILE * upkeep_multiplier * upkeep_star_multiplier * temperature_multiplier)		//Eclipse edit: Add in shield energy temperature multiplier if the room is too cold.
 
 	if(powernet && !input_cut && (running == SHIELD_RUNNING || running == SHIELD_OFF))
 		var/energy_buffer = 0
@@ -283,6 +357,35 @@
 		current_energy += round(energy_buffer)
 	else
 		current_energy -= round(upkeep_power_usage)	// We are shutting down, or we lack external power connection. Use energy from internal source instead.
+
+	// // // BEGIN ECLIPSE EDITS // // //
+	// This is the part where we put out heat.
+	if(_safety)		//We still have our safety variable...
+		var/transfer_moles = 0.79 * MOLES_CELLSTANDARD * 2		//I imagine the generator's gotta be lorg.
+		//Also, process only happens every 2 seconds, hence the *2 at the end there.
+		var/datum/gas_mixture/intake = environment.remove(transfer_moles)		//Sucked up by the intake...
+		if(intake)
+			
+/*	Add thermal energy to the intake air. The energy we add is equivalent to the
+ *	current energy usage, which is then converted to waste heat based on the
+ *	coeffecient of performance (or, rather, a variation of the HVAC definition.
+ *	A coefficient of performance of 90% in this case means that 10% of the work
+ *	turns to heat.) We then multiply this by 0.75 if the shield generator is off,
+ *	or 1 if it's active; after that we quarter it because we want it biased toward
+ *	passive usage.
+ *
+ *	On the upkeep, we do the same thing, except we multiply the "0.75" bit by 4
+ *	because it's passive usage. Then, we add it all together, and boom.
+ */
+			var/normal_power_thermal_energy = (power_usage * (100-coefficient_of_performance) * (0.75 + (_working * 0.25)) * 0.25)
+			var/upkeep_power_thermal_energy = (upkeep_power_usage * (100-coefficient_of_performance) * 3)
+
+			intake.add_thermal_energy(normal_power_thermal_energy + upkeep_power_thermal_energy)
+			
+			egt = intake.temperature
+			//and now we exhaust the air back out.
+		environment.merge(intake)
+	// // // END ECLIPSE EDITS // // //
 
 	if(current_energy <= 0)
 		energy_failure()
@@ -353,11 +456,22 @@
 	data["power_usage"] = round(power_usage / 1000)
 	data["offline_for"] = offline_for * 2
 	data["shutdown"] = emergency_shutdown
-
-
+	
+	// // // BEGIN ECLIPSE EDITS // // //
+	// Monitoring.
+	data["temp_internal"] = itt
+	data["temp_exhaust"] = egt
+	
+	//Thresholds, used in annunciator panel and bar colouring.
+	data["thr_cold"] = threshold_cold
+	data["thr_norm"] = threshold_normal
+	data["thr_crit"] = threshold_critical
+	data["thr_htco"] = threshold_high_temperature_cutout
+	// // // END ECLIPSE EDITS // // //
+	
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "shieldgen.tmpl", src.name, 650, 800)
+		ui = new(user, src, ui_key, "shieldgen_eclipse.tmpl", src.name, 650, 800)		//Eclipse edit.
 		ui.set_initial_data(data)
 		ui.open()
 		ui.set_auto_update(1)
@@ -412,6 +526,12 @@
 		log_event(EVENT_DISABLED, src)
 
 	if(href_list["start_generator"])
+		// // // BEGIN ECLIPSE EDITS // // //
+		//this is how we reset the shutdown alarm. By turning it back on!
+		if(threshold_shutdown_alarm)
+			threshold_shutdown_alarm = FALSE
+			threshold_alarm = FALSE
+		// // // END ECLIPSE EDITS // // //
 		running = SHIELD_RUNNING
 		regenerate_field()
 		log_event(EVENT_ENABLED, src)
@@ -432,6 +552,7 @@
 		offline_for += 300 //5 minutes, given that procs happen every 2 seconds
 		shutdown_field()
 		emergency_shutdown = TRUE
+		input_cap = 1		//Eclipse edit: Negligible input, because it's an E-stop!
 		log_event(EVENT_DISABLED, src)
 		if(prob(temp_integrity - 50) * 1.75)
 			spawn()

--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -46,6 +46,7 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/engineering/gravity_generator)
 "aaj" = (
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/shield_generator)
 "aak" = (
@@ -1824,6 +1825,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/shield_generator)
 "aey" = (
@@ -7224,6 +7226,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/long_range_scanner)
 "aqY" = (
@@ -7267,6 +7274,11 @@
 "arb" = (
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/mechanical,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/long_range_scanner)
 "arc" = (
@@ -7654,6 +7666,10 @@
 /area/eris/medical/medbreak)
 "asb" = (
 /obj/machinery/power/long_range_scanner/hull/installed,
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/long_range_scanner)
 "asc" = (
@@ -19654,6 +19670,10 @@
 /obj/machinery/camera/network/engineering{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 8;
+	tag = "icon-manifold-f (EAST)"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/shield_generator)
 "aUC" = (
@@ -19720,8 +19740,10 @@
 /obj/structure/table/standard,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25
+	pixel_x = 25;
+	report_danger_level = 0
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/shield_generator)
 "aUN" = (
@@ -20720,6 +20742,8 @@
 /obj/machinery/camera/network/engineering{
 	dir = 4
 	},
+/obj/spawner/material/building/low_chance,
+/obj/spawner/material/building/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/eris/engineering/gravity_generator)
 "aXg" = (
@@ -21572,6 +21596,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/shield_generator)
 "aZw" = (
@@ -22579,6 +22604,11 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/long_range_scanner)
@@ -24086,6 +24116,7 @@
 	dir = 4;
 	pixel_x = -28
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/shield_generator)
 "bfN" = (
@@ -24720,6 +24751,11 @@
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 22
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/long_range_scanner)
@@ -32052,12 +32088,16 @@
 /turf/simulated/wall,
 /area/eris/medical/chemstor)
 "byJ" = (
-/obj/structure/table/rack/shelf,
-/obj/spawner/material/building/low_chance,
-/obj/spawner/material/building/low_chance,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -28
+	},
+/obj/machinery/atmospherics/unary/freezer{
+	dir = 4;
+	icon_state = "freezer_1";
+	power_setting = 60;
+	set_temperature = 173;
+	use_power = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/engineering/gravity_generator)
@@ -66973,6 +67013,9 @@
 /area/eris/maintenance/oldbridge)
 "dfm" = (
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/engineering/gravity_generator)
 "dfn" = (
@@ -68072,6 +68115,12 @@
 /area/erida/maintenance/starboardsection2deck4)
 "dii" = (
 /obj/structure/table/rack/shelf,
+/obj/spawner/material/building/low_chance,
+/obj/spawner/material/building/low_chance,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	tag = "icon-intact (NORTHEAST)"
+	},
 /obj/spawner/material/building/low_chance,
 /obj/spawner/material/building/low_chance,
 /turf/simulated/floor/tiled/dark,
@@ -79137,6 +79186,12 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/office)
+"dSR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/eris/engineering/shield_generator)
 "eeb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/light{
@@ -79258,6 +79313,14 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/erida/hallway/side/docks)
+"hhq" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/engineering/long_range_scanner)
 "hlD" = (
 /obj/structure/catwalk,
 /obj/spawner/mob/spiders/cluster,
@@ -79291,6 +79354,14 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/propulsion/left)
+"hKJ" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/engineering/long_range_scanner)
 "hLj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -79366,6 +79437,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/atmos)
+"jRj" = (
+/obj/machinery/constructable_frame/machine_frame,
+/turf/simulated/floor/tiled/dark,
+/area/eris/engineering/gravity_generator)
 "kaV" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/item/storage/fancy/vials,
@@ -79385,12 +79460,27 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/medical/medbreak)
+"knD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 5;
+	tag = "icon-intact (NORTHEAST)"
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/eris/engineering/shield_generator)
 "ksa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /turf/simulated/floor/plating,
 /area/erida/maintenance/sciweapondeck)
+"kFL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/engineering/long_range_scanner)
 "kJZ" = (
 /obj/structure/window/basic,
 /obj/machinery/button/remote/driver{
@@ -79517,10 +79607,26 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/propulsion/left)
+"ncB" = (
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eris/engineering/gravity_generator)
 "nwL" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/security/lobby)
+"nCy" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	tag = "icon-manifold-f (EAST)"
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/engineering/shield_generator)
 "odd" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79622,6 +79728,13 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/miningdock)
+"pST" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4;
+	tag = "icon-manifold-f (EAST)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eris/engineering/gravity_generator)
 "pVp" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -79640,6 +79753,16 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/engine_room)
+"qnY" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 1;
+	tag = "icon-manifold-f (NORTH)"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eris/engineering/gravity_generator)
 "qrQ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
@@ -79682,16 +79805,16 @@
 /obj/machinery/telecomms/server/presets/common,
 /turf/simulated/floor/bluegrid,
 /area/eris/command/tcommsat/chamber)
+"rPb" = (
+/obj/spawner/mob/spiders/cluster,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/erida/maintenance/starboardsection2deck1)
 "spc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/erida/maintenance/sciweapondeck)
-"rPb" = (
-/obj/spawner/mob/spiders/cluster,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/erida/maintenance/starboardsection2deck1)
 "szA" = (
 /obj/structure/sign/double/barsign,
 /turf/simulated/wall/r_wall,
@@ -79709,6 +79832,21 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/propulsion/left)
+"sSa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/dark,
+/area/eris/engineering/gravity_generator)
 "thV" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -79756,6 +79894,20 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/propulsion/left)
+"tUL" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/engineering/long_range_scanner)
+"uej" = (
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/plating,
+/area/eris/engineering/shield_generator)
 "ues" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/light{
@@ -79798,6 +79950,10 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/security/lobby)
+"uBS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/turf/simulated/floor/tiled/dark,
+/area/eris/engineering/gravity_generator)
 "uHz" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -79812,6 +79968,12 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/eris/engineering/propulsion/left)
+"vfX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eris/engineering/gravity_generator)
 "vhr" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
@@ -79850,6 +80012,19 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/security/lobby)
+"vxv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eris/engineering/gravity_generator)
 "vLS" = (
 /turf/space,
 /area/eris/maintenance/junk)
@@ -79932,6 +80107,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
 /area/erida/maintenance/substation/starboard_section)
+"xpV" = (
+/obj/machinery/atmospherics/unary/vent_pump{
+	external_pressure_bound = 0;
+	external_pressure_bound_default = 0;
+	icon_state = "map_vent_in";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	internal_pressure_bound_default = 4000;
+	pressure_checks = 2;
+	pressure_checks_default = 2;
+	pump_direction = 0;
+	use_power = 1
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/engineering/shield_generator)
 "xwl" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/steel/techfloor,
@@ -94506,13 +94696,13 @@ aaj
 aUB
 aex
 bfM
-aae
+uej
 dii
 aXf
 afC
 ale
 byJ
-dii
+jRj
 aqJ
 bzA
 arv
@@ -94655,15 +94845,15 @@ aan
 aaa
 aac
 aaj
-aat
+dSR
 aey
 aff
 aHj
-dfj
-afC
-afC
-ale
-afC
+qnY
+uBS
+uBS
+sSa
+pST
 dfm
 aqI
 aqW
@@ -94811,7 +95001,7 @@ acc
 aez
 afg
 afV
-agu
+vxv
 agu
 ajl
 alg
@@ -94822,7 +95012,7 @@ aqX
 arx
 arN
 asb
-arM
+kFL
 aqI
 aaa
 aaa
@@ -94958,12 +95148,12 @@ cvI
 aan
 aaa
 aac
-aaj
-aat
+xpV
+knD
 aeA
 afh
 aac
-aXM
+ncB
 dik
 ajq
 alh
@@ -94974,7 +95164,7 @@ arb
 arz
 arM
 arN
-arM
+hKJ
 aqI
 aaa
 aaa
@@ -95110,12 +95300,12 @@ dhp
 aan
 aaa
 aac
-aaj
-aaj
+xpV
+nCy
 aZv
 aUM
-aae
-afC
+uej
+vfX
 bee
 ajD
 ajD
@@ -95124,9 +95314,9 @@ afC
 aqJ
 bbY
 bhw
-arM
-arM
-arM
+tUL
+tUL
+hhq
 aqI
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

Adds an overheating mechanic to the shields.

## Why It's Good For The Game

This update is part of a balancing pass to make shields less set-and-forget. 

Shields will now generate heat based on the following factors:
* Ambient temperature
* Total power draw
* Power required to maintain the shields' integrity.

The shields are air-cooled, meaning they take air in from the environment, heat it based on the power draw, and exhaust it back into the environment (much like an air-cooled computer tower). At lower ambient temperatures, the power draw required to maintain the shields is higher, as the shield generator is not at operating temperature; the lower the temperature, the higher the required power draw needed to sustain the shields. This is capped at a maximum of a 4× multiplier and a floor of a 1× multiplier.

If the shields reach 125°C, they will shut off, in order to prevent damage to the generator. 

![image](https://user-images.githubusercontent.com/1784490/162644306-beb704ae-f7dd-49eb-b835-6365dfb3b921.png)
*Screenshot of the changes to the NanoUI panel for the shield generator. Of note: Exhaust gas temperature isn't used in any calculations, but is included as a visual aid to the player to see just how hard they're pushing the shield generator.*

## Changelog
:cl: EvilJackCarver
add: Shield generator now has an overheat mechanic. Don't push it too hard!
tweak: Map and NanoUI tweaks in relation to the shield generator overheat PR.
fix: Long-range scanner, once again, starts wired into mains power.
/:cl:
