### PR TITLE
Finally Fixing Bridge Officer Access

### DIFF
--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -232,7 +232,11 @@
 	desc = "Manufacturing"
 	access_type = ACCESS_TYPE_NONE
 
-// /var/const/free_access_id = 37
+/var/const/access_supply_consoles = 37 //Eclipse Edit - console access
+/datum/access/supplyconsoles
+	id = access_supply_consoles
+	desc = "Supply Consoles"
+	region = ACCESS_REGION_SUPPLY
 
 // /var/const/free_access_id = 38
 
@@ -248,7 +252,11 @@
 	desc = "Chief Medical Officer"
 	region = ACCESS_REGION_MEDBAY
 
-// /var/const/free_access_id = 39
+/var/const/access_rd_consoles = 39 //Eclipse Edit - console access
+/datum/access/rdconsoles
+	id = access_rd_consoles
+	desc = "Research Consoles"
+	region = ACCESS_REGION_RESEARCH
 
 // /var/const/free_access_id = 40
 
@@ -282,9 +290,17 @@
 	desc = "Surgery"
 	region = ACCESS_REGION_MEDBAY
 
-// /var/const/free_access_id = 46
+/var/const/access_atmos_consoles = 46 //Eclipse Edit - consoles access
+/datum/access/atmosconsoles
+	id = access_atmos_consoles
+	desc = "Atmospherics Consoles"
+	region = ACCESS_REGION_ENGINEERING
 
-// /var/const/free_access_id = 47
+/var/const/access_engine_consoles = 47 //Eclipe Edit - consoles access
+/datum/access/engineconsoles
+	id = access_engine_consoles
+	desc = "Engineering Consoles"
+	region = ACCESS_REGION_ENGINEERING
 
 /var/const/access_mining = 48
 /datum/access/mining
@@ -304,9 +320,17 @@
 	desc = "Cargo Office"
 	region = ACCESS_REGION_SUPPLY
 
-// /var/const/free_access_id = 51
+/var/const/access_moebius_consoles = 51 //Eclipse Edit - Console access
+/datum/access/moebiusconsoles
+	id = access_moebius_consoles
+	desc = "Lazarus Consoles"
+	region = ACCESS_REGION_MEDBAY
 
-// /var/const/free_access_id = 52
+/var/const/access_armory_consoles = 52
+/datum/access/armoryconsoles
+	id = access_armory_consoles
+	desc = "Armory Consoles"
+	region = ACCESS_REGION_SECURITY
 
 /var/const/access_heads_vault = 53
 /datum/access/heads_vault
@@ -404,7 +428,11 @@
 	desc = "Paramedic's Office"
 	region = ACCESS_REGION_MEDBAY
 
-// /var/const/free_access_id = 69
+/var/const/access_sec_consoles = 69 //Eclipse Edit - consoles access
+/datum/access/secconsoles
+	id = access_sec_consoles
+	desc = "Security Consoles"
+	region = ACCESS_REGION_SECURITY
 
 /**************
 * NeoTheology *

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -194,7 +194,7 @@ Assist other departments from the bridge when the Captain has no work for you. Y
 							 /datum/computer_file/program/alarm_monitor)
 
 
-	access = list(access_RC_announce, access_keycard_auth, access_heads, access_external_airlocks, access_bar, access_kitchen, access_network, access_engine, access_moebius, access_rd, access_security, access_sec_doors)
+	access = list(access_RC_announce, access_keycard_auth, access_heads, access_external_airlocks, access_bar, access_kitchen, access_network, access_atmos_consoles, access_engine_consoles, access_moebius_consoles, access_rd_consoles, access_armory_consoles, access_sec_consoles, access_sec_doors, access_supply_consoles)
 
 	stat_modifiers = list(
 		STAT_ROB = 15,

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -20,7 +20,7 @@
 	outfit_type = /decl/hierarchy/outfit/job/engineering/exultant
 
 	access = list(
-		access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
+		access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels, access_engine_consoles, access_atmos_consoles,
 		access_teleporter, access_network, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,
 		access_heads, access_construction, access_sec_doors,
 		access_ce, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload, access_change_engineering
@@ -78,7 +78,7 @@ Your second loyalty is to your workers. Ensure they are paid, fed and safe. Don'
 
 	access = list(
 		access_eva, access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
-		access_external_airlocks, access_construction, access_atmospherics
+		access_external_airlocks, access_construction, access_atmospherics, access_engine_consoles, access_atmos_consoles
 	)
 
 	stat_modifiers = list(

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -17,7 +17,7 @@
 	access = list(
 		access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_merchant, access_mining,
 		access_heads, access_mining_station, access_RC_announce, access_keycard_auth, access_sec_doors,
-		access_eva, access_external_airlocks, access_change_cargo, access_artist
+		access_eva, access_external_airlocks, access_change_cargo, access_artist, access_supply_consoles
 	)
 	ideal_character_age = 40
 	stat_modifiers = list(
@@ -83,7 +83,7 @@ Your second loyalty is to the Union. Ensure it retains good relations with priva
 
 	access = list(
 		access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining,
-		access_mining_station
+		access_mining_station, access_supply_consoles
 	)
 
 	stat_modifiers = list(
@@ -157,7 +157,7 @@ Character Expectations:<br>\
 
 	access = list(
 		access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining,
-		access_mining_station
+		access_mining_station, access_supply_consoles
 	)
 
 
@@ -191,7 +191,7 @@ Character Expectations:<br>\
 	supervisors = "the Union Merchant"
 	selection_color = "#dddddd"
 	also_known_languages = list(LANGUAGE_JIVE = 100)
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station, access_artist, access_theatre)
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station, access_artist, access_theatre, access_supply_consoles)
 
 	outfit_type = /decl/hierarchy/outfit/job/cargo/artist
 	wage = WAGE_LABOUR_DUMB	//Barely a retaining fee. Actor can busk for credits to keep themselves fed

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -17,7 +17,7 @@
 
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_genetics, access_heads,
-		access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
+		access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce, access_moebius_consoles,
 		access_keycard_auth, access_sec_doors, access_psychiatrist, access_eva, access_maint_tunnels,
 		access_external_airlocks, access_paramedic, access_research_equipment, access_change_medbay
 	)
@@ -76,7 +76,7 @@ Your second loyalty is to your career with Lazarus, and to your coworkers in bot
 
 	access = list(
 		access_moebius, access_medical_equip, access_maint_tunnels, access_morgue, access_surgery, access_chemistry, access_virology,
-		access_genetics
+		access_genetics, access_moebius_consoles
 	)
 
 	stat_modifiers = list(
@@ -134,7 +134,7 @@ Your second loyalty is to your career with Lazarus, and to your coworkers in bot
 	outfit_type = /decl/hierarchy/outfit/job/medical/chemist
 
 	access = list(
-		access_moebius, access_medical_equip, access_maint_tunnels, access_morgue, access_surgery, access_chemistry, access_virology
+		access_moebius, access_medical_equip, access_maint_tunnels, access_morgue, access_surgery, access_chemistry, access_virology, access_moebius_consoles
 	)
 
 	stat_modifiers = list(
@@ -185,7 +185,7 @@ Your second loyalty is to your career with Lazarus, and to your coworkers in bot
 	outfit_type = /decl/hierarchy/outfit/job/medical/psychiatrist
 
 	access = list(
-		access_moebius, access_medical_equip, access_morgue, access_psychiatrist
+		access_moebius, access_medical_equip, access_morgue, access_psychiatrist, access_moebius_consoles
 	)
 
 	stat_modifiers = list(
@@ -221,7 +221,7 @@ Your second loyalty is to your career with Lazarus, and to your coworkers in bot
 	outfit_type = /decl/hierarchy/outfit/job/medical/paramedic
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_surgery, access_paramedic,
-		access_eva, access_maint_tunnels, access_external_airlocks
+		access_eva, access_maint_tunnels, access_external_airlocks, access_moebius_consoles
 	)
 
 	stat_modifiers = list(

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -21,7 +21,7 @@
 		access_moebius, access_medical_equip, access_chemistry, access_virology, access_cmo, access_surgery, access_psychiatrist,
 		access_robotics, access_xenobiology, access_ai_upload, access_tech_storage, access_eva, access_external_airlocks,
 		access_RC_announce, access_keycard_auth, access_tcomsat, access_gateway, access_xenoarch, access_network, access_maint_tunnels, access_research_equipment,
-		access_change_research
+		access_change_research, access_rd_consoles, access_moebius_consoles
 	)
 	ideal_character_age = 50
 
@@ -76,7 +76,7 @@ As a scientist, your first loyalty is to knowledge and Discovery, the ultimate g
 
 	access = list(
 		access_robotics, access_tox, access_tox_storage, access_moebius, access_maint_tunnels, access_xenobiology, access_xenoarch, access_research_equipment,
-		access_genetics
+		access_genetics, access_moebius_consoles
 	)
 
 	stat_modifiers = list(
@@ -126,7 +126,7 @@ Explore, learn and adventure, do anything to advance the cause of knowledge"
 	outfit_type = /decl/hierarchy/outfit/job/science/roboticist
 
 	access = list(
-		access_robotics, access_tox, access_maint_tunnels, access_tox_storage, access_morgue, access_moebius, access_research_equipment
+		access_robotics, access_tox, access_maint_tunnels, access_tox_storage, access_morgue, access_moebius, access_research_equipment, access_moebius_consoles
 	) //As a job that handles so many corpses, it makes sense for them to have morgue access.
 
 	software_on_spawn = list(/datum/computer_file/program/chem_catalog)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -23,7 +23,7 @@
 		access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
 		access_moebius, access_engine, access_mining, access_construction, access_mailsorting,
 		access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway,
-		access_external_airlocks, access_change_sec
+		access_external_airlocks, access_change_sec, access_moebius_consoles
 	)
 
 	stat_modifiers = list(
@@ -83,7 +83,7 @@
 	access = list(
 		access_security, access_moebius, access_medspec, access_engine, access_mailsorting,
 		access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_morgue,
-		access_external_airlocks
+		access_external_airlocks, access_moebius_consoles
 	)
 
 	stat_modifiers = list(
@@ -135,7 +135,7 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/security/inspector
 
-	access = list(access_security, access_moebius, access_medspec, access_engine, access_mailsorting, access_eva, access_sec_doors, access_forensics_lockers, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks)
+	access = list(access_security, access_moebius, access_medspec, access_engine, access_mailsorting, access_eva, access_sec_doors, access_forensics_lockers, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks, access_moebius_consoles)
 
 	stat_modifiers = list(
 		STAT_BIO = 15,
@@ -190,7 +190,7 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/security/medspec
 
-	access = list(access_security, access_moebius, access_medspec, access_engine, access_mailsorting, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks, access_medical_equip)
+	access = list(access_security, access_moebius, access_medspec, access_engine, access_mailsorting, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks, access_medical_equip, access_moebius_consoles)
 
 	stat_modifiers = list(
 		STAT_BIO = 25,
@@ -246,7 +246,7 @@
 
 	access = list(
 		access_security, access_moebius, access_engine, access_mailsorting,access_eva,
-		access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks
+		access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks, access_moebius_consoles
 	)
 
 	stat_modifiers = list(

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -6,7 +6,7 @@
 	icon_keyboard = "med_key"
 	icon_screen = "medcomp"
 	light_color = COLOR_LIGHTING_GREEN_MACHINERY
-	req_one_access = list(access_moebius, access_forensics_lockers)
+	req_one_access = list(access_moebius_consoles, access_forensics_lockers)
 	circuit = /obj/item/electronics/circuitboard/med_data
 	var/obj/item/card/id/scan
 	var/authenticated

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -5,7 +5,7 @@
 	icon_keyboard = "tech_key"
 	icon_screen = "robot"
 	light_color = COLOR_LIGHTING_PURPLE_MACHINERY
-	req_access = list(access_robotics)
+	req_one_access = list(access_robotics, access_rd_consoles)
 	circuit = /obj/item/electronics/circuitboard/robotics
 
 	var/safety = 1

--- a/code/modules/mob/living/silicon/robot/drone/drone_console.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_console.dm
@@ -6,7 +6,7 @@ GLOBAL_LIST_INIT(drones, list())
 	icon = 'icons/obj/computer.dmi'
 	icon_keyboard = "power_key"
 	icon_screen = "dron_control_monitor"
-	req_access = list(access_engine_equip)
+	req_access = list(access_engine_consoles)
 	circuit = /obj/item/electronics/circuitboard/drone_control
 
 	//Used when pinging drones.

--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -6,7 +6,7 @@
 	program_key_state = "atmos_key"
 	program_menu_icon = "shuffle"
 	extended_desc = "This program allows remote control of air alarms. This program can not be run on tablet computers."
-	required_access = access_atmospherics
+	required_access = access_atmos_consoles
 	requires_ntnet = 1
 	network_destination = "atmospheric control system"
 	requires_ntnet_feature = NTNET_SYSTEMCONTROL

--- a/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
@@ -7,7 +7,7 @@
 	program_menu_icon = "battery-3"
 	extended_desc = "This program connects to sensors to provide information about electrical systems"
 	ui_header = "power_norm.gif"
-	required_access = access_engine
+	required_access = access_engine_consoles
 	requires_ntnet = 1
 	network_destination = "power monitoring system"
 	size = 9

--- a/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
@@ -6,7 +6,7 @@
 	program_key_state = "rd_key"
 	program_menu_icon = "power"
 	extended_desc = "This program allows remote control of power distribution systems. Cannot be run on tablet computers."
-	required_access = access_engine
+	required_access = access_engine_consoles
 	requires_ntnet = 1
 	network_destination = "RCON remote control system"
 	requires_ntnet_feature = NTNET_SYSTEMCONTROL

--- a/code/modules/modular_computers/file_system/programs/engineering/shield_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/shield_control.dm
@@ -11,10 +11,10 @@
 	nanomodule_path = /datum/nano_module/shield_control
 	program_icon_state = "engine"
 	extended_desc = "This program allows remote management of the hull shield generator. Cannot be run on tablet computers."
-	required_access = access_atmospherics
+	required_access = access_atmos_consoles
 	requires_ntnet = 1
 	network_destination = "shield control system"
-	required_access = access_engine //Restricted to engineering and the bridge
+	required_access = access_engine_consoles //Restricted to engineering and the bridge
 	requires_ntnet_feature = NTNET_SYSTEMCONTROL
 	usage_flags = PROGRAM_LAPTOP | PROGRAM_CONSOLE
 	size = 24

--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -7,7 +7,7 @@
 	program_menu_icon = "notice"
 	extended_desc = "This program connects to specially calibrated supermatter sensors to provide information on the status of supermatter-based engines."
 	ui_header = "smmon_0.gif"
-	required_access = access_engine
+	required_access = access_engine_consoles
 	requires_ntnet = 1
 	network_destination = "supermatter monitoring system"
 	size = 5

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -4,17 +4,17 @@
 		return 0
 	switch(network)
 		if(NETWORK_ENGINEERING, NETWORK_ALARM_ATMOS, NETWORK_ALARM_CAMERA, NETWORK_ALARM_FIRE, NETWORK_ALARM_POWER)
-			return access_engine
+			return access_engine_consoles
 		if(NETWORK_MEDICAL,NETWORK_RESEARCH)
-			return access_moebius
+			return access_moebius_consoles
 		if(NETWORK_MINE)
-			return access_mailsorting // Cargo office - all cargo staff should have access here.
+			return access_supply_consoles // Cargo office - all cargo staff should have access here.
 		if(NETWORK_ROBOTS)
-			return access_rd
+			return access_rd_consoles
 		if(NETWORK_PRISON)
-			return access_security
+			return access_sec_consoles
 		if(NETWORK_ENGINEERING,NETWORK_ENGINE)
-			return access_engine
+			return access_engine_consoles
 		if(NETWORK_COMMAND)
 			return access_heads
 		if(NETWORK_THUNDER)

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -23,7 +23,7 @@
 	if(active_record)
 		user << browse_rsc(active_record.photo_front, "front_[active_record.uid].png")
 		user << browse_rsc(active_record.photo_side, "side_[active_record.uid].png")
-		data["pic_edit"] = check_access(user, access_heads) || check_access(user, access_security)
+		data["pic_edit"] = check_access(user, access_heads) || check_access(user, access_sec_consoles)
 		data += active_record.generate_nano_data(user_access)
 	else
 		var/list/all_records = list()
@@ -36,8 +36,8 @@
 			)))
 		data["all_records"] = all_records
 		data["creation"] = check_access(user, access_heads)
-		data["dnasearch"] = check_access(user, access_moebius) || check_access(user, access_forensics_lockers)
-		data["fingersearch"] = check_access(user, access_security)
+		data["dnasearch"] = check_access(user, access_moebius_consoles) || check_access(user, access_forensics_lockers)
+		data["fingersearch"] = check_access(user, access_sec_consoles)
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)

--- a/code/modules/modular_computers/file_system/programs/medical/chem_catalog.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/chem_catalog.dm
@@ -8,6 +8,7 @@
 	available_on_ntnet = 1
 	nanomodule_path = /datum/nano_module/chem_catalog
 	usage_flags = PROGRAM_ALL
+	required_access = access_moebius_consoles  //Eclipse Edit - anti-powergaming measure. No more of this "just google it, chemistry isn't that hard"
 
 /datum/nano_module/chem_catalog
 	name = "Chemistry Catalog"

--- a/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
@@ -7,7 +7,7 @@
 	program_key_state = "med_key"
 	program_menu_icon = "heart"
 	extended_desc = "This program connects to life signs monitoring system to provide basic information on crew health."
-	required_access = access_moebius
+	required_access = access_moebius_consoles
 	requires_ntnet = 1
 	network_destination = "crew lifesigns monitoring system"
 	size = 11

--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -12,7 +12,7 @@ LEGACY_RECORD_STRUCTURE(all_warrants, warrant)
 	program_menu_icon = "star"
 	requires_ntnet = 1
 	available_on_ntnet = 1
-	required_access = access_security
+	required_access = access_sec_consoles
 	nanomodule_path = /datum/nano_module/digitalwarrant/
 
 /datum/nano_module/digitalwarrant/

--- a/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
+++ b/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
@@ -8,7 +8,7 @@
 	program_menu_icon = "locked"
 	requires_ntnet = 1
 	available_on_ntnet = 1
-	required_access = access_armory
+	required_access = access_armory_consoles
 	nanomodule_path = /datum/nano_module/forceauthorization/
 
 /datum/nano_module/forceauthorization/

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -211,14 +211,14 @@ FIELD_SHORT("Email",email, null, access_change_ids)
 FIELD_NUM("Account",account, null, access_change_ids)
 
 // MEDICAL RECORDS
-FIELD_LIST("Blood Type", bloodtype, GLOB.blood_types, access_moebius, access_moebius)
-FIELD_LONG("Medical Record", medRecord, access_moebius, access_moebius)
+FIELD_LIST("Blood Type", bloodtype, GLOB.blood_types, access_moebius_consoles, access_moebius_consoles)
+FIELD_LONG("Medical Record", medRecord, access_moebius_consoles, access_moebius_consoles)
 
 // SECURITY RECORDS
-FIELD_LIST("Criminal Status", criminalStatus, GLOB.security_statuses, access_security, access_security)
-FIELD_LONG("Security Record", secRecord, access_security, access_security)
-FIELD_SHORT("DNA", dna, access_security, access_security)
-FIELD_SHORT("Fingerprint", fingerprint, access_security, access_security)
+FIELD_LIST("Criminal Status", criminalStatus, GLOB.security_statuses, access_sec_consoles, access_sec_consoles)
+FIELD_LONG("Security Record", secRecord, access_sec_consoles, access_sec_consoles)
+FIELD_SHORT("DNA", dna, access_sec_consoles, access_sec_consoles)
+FIELD_SHORT("Fingerprint", fingerprint, access_sec_consoles, access_sec_consoles)
 
 // EMPLOYMENT RECORDS
 FIELD_LONG("Employment Record", emplRecord, access_heads, access_heads)

--- a/code/modules/reagents/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/machinery/chem_dispenser.dm
@@ -14,6 +14,7 @@
 	use_power = NO_POWER_USE // Handles power use in Process()
 	layer = BELOW_OBJ_LAYER
 	circuit = /obj/item/electronics/circuitboard/chemical_dispenser
+	req_access = list(access_chemistry) //Eclipse Edit - anti-powergaming measure, locking these machines so that only those who have been believably trained in their use can touch them.
 
 	var/ui_title = "Chem Dispenser 5000"
 	var/obj/item/cell/medium/cell
@@ -126,6 +127,9 @@
 		amount = CLAMP(amount, 0, 120)
 
 	if(href_list["dispense"])
+		if(!src.allowed(usr))
+			to_chat(usr, SPAN_WARNING("Access denied."))
+			return
 		if (dispensable_reagents.Find(href_list["dispense"]) && beaker && beaker.is_refillable())
 			var/obj/item/reagent_containers/B = src.beaker
 			var/datum/reagents/R = B.reagents
@@ -270,6 +274,7 @@ obj/machinery/chemical_dispenser/soda/update_icon()
 	icon = 'icons/obj/machines/chemistry.dmi'
 	icon_state = "industrial_dispenser"
 	ui_title = "Industrial Dispenser 4835"
+	req_access = list(access_moebius) //Eclipse Edit - anti-powergaming measure, see note on parent object above
 
 	circuit = /obj/item/electronics/circuitboard/chemical_dispenser/industrial
 

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -12,7 +12,7 @@
 	var/produces_heat = 1
 	idle_power_usage = 800
 	var/delay = 10
-	req_access = list(access_rd) //Only the R&D can change server settings.
+	req_access = list(access_rd_consoles) //Only the R&D can change server settings.
 	circuit = /obj/item/electronics/circuitboard/rdserver
 
 /obj/machinery/r_n_d/server/Destroy()

--- a/maps/CEVEris/datums/reports.dm
+++ b/maps/CEVEris/datums/reports.dm
@@ -78,7 +78,7 @@
 
 /datum/computer_file/report/recipient/sec/New()
 	..()
-	set_access(access_security)
+	set_access(access_sec_consoles)
 	set_access(access_heads, override = 0)
 
 /datum/computer_file/report/recipient/sec/warning
@@ -135,7 +135,7 @@
 	add_field(/datum/report_field/pencode_text, "Summary")
 	add_field(/datum/report_field/pencode_text, "Observations")
 	add_field(/datum/report_field/signature, "Signature")
-	set_access(access_edit = access_security)
+	set_access(access_edit = access_sec_consoles)
 
 /datum/computer_file/report/recipient/sec/incident
 	form_name = "SIR-AS-12"
@@ -156,7 +156,7 @@
 	add_field(/datum/report_field/pencode_text, "Description of Items/Property", "\[small\]\[i\](D-Damaged, E-Evidence, L-Lost, R-Recovered, S-Stolen)\[/i\]\[/small\]")
 	add_field(/datum/report_field/pencode_text, "Narrative")
 	add_field(/datum/report_field/signature, "Reporting Operative's signature")
-	set_access(access_edit = access_security)
+	set_access(access_edit = access_sec_consoles)
 
 /datum/computer_file/report/recipient/sec/evidence
 	form_name = "EPF-AS-02b"
@@ -171,11 +171,11 @@
 	add_field(/datum/report_field/time, "Time")
 	add_field(/datum/report_field/people/from_manifest, "Confiscated from")
 	add_field(/datum/report_field/pencode_text, "List of items in custody/evidence lockup")
-	set_access(access_edit = access_security)
+	set_access(access_edit = access_sec_consoles)
 	temp_field = add_field(/datum/report_field/signature, "Gunnery Sergeant's signature")
-	temp_field.set_access(access_edit = list(access_security, access_armory))
+	temp_field.set_access(access_edit = list(access_sec_consoles, access_armory_consoles))
 	temp_field = add_field(/datum/report_field/signature, "Detective/MedSpec's signature")
-	temp_field.set_access(access_edit = list(access_security, access_forensics_lockers))
+	temp_field.set_access(access_edit = list(access_sec_consoles, access_forensics_lockers))
 
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- creates new access levels specifically for department consoles
- changes access requirements of consoles / programs to new console accesses
- alters Boff access to remove department accesses they don't need and grants them console access. Fixes #1495 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your Pull Request fixes an issue, please write "Fixes #1234" or "Closes #5678" so the issue automatically closes when the PR is merged. For more information, see Contributing.MD for further information. --->

## Why It's Good For The Game
These changes allow me to finally remove the scuffed access from Bridge Officers, as they'll no longer need to have odd access across the ship. This also makes several new access levels to allow heads more granularity when assigning access to departments, as consoles / programs are their own access level now, rather than sharing door / equipment access.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed Bridge Officer access. Consoles / programs now have their own access levels by department.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
