### PR TITLE
Shield generator overheat fix

### DIFF
--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -127,8 +127,10 @@
 	connect_to_network()
 	wires = new(src)
 	
-	radio = new /obj/item/device/radio{channels=list("Engineering")}(src)
+	// // // BEGIN ECLIPSE EDITS // // //
+	radio = new /obj/item/device/radio{channels=list("Engineering", "Command")}(src)
 	assign_uid()
+	// // // END ECLIPSE EDITS // // //
 
 	//Add all allowed modes to our mode list for users to select
 	mode_list = list()
@@ -295,26 +297,30 @@
 		
 		//we'll put out heat later, after we calculate energy usage.
 		
-	//Overheat code.
+	//Overheat code.	
 	if((itt < threshold_critical) && threshold_alarm)	//Overheat alarm sounded, but we're cooled down.
 		if(last_overheat < (world.time - 15 SECONDS))		//Give us some hysterisis, just in case.
 			if(!threshold_shutdown_alarm)		//If we caught it before the system cut off, then we announce we're cool enough.
-				radio.autosay("Shield generator returning to safe operating temperatures.", "Shield Generator monitor", "Engineering")
+				radio.autosay("Shield generator returning to safe operating temperatures.", "Shield monitor", "Engineering")
+				radio.autosay("Shield generator returning to safe operating temperatures.", "Shield monitor", "Command")
 			threshold_alarm = FALSE
+			threshold_shutdown_alarm = FALSE
 
 	if(itt > threshold_critical)	//we're overheating.
 		last_overheat = world.time
 		if(!threshold_alarm)		//alarm hasn't sounded.
-			radio.autosay("WARNING: Shield generator temperature very high. Recommend reducing load immediately to return shield generator to normal operating temperatures and avoid a possible automatic emergency stop. Any internal damages caused by overheating are NOT covered by your manufacturer's warranty.", "Shield Generator monitor", "Engineering")
+			radio.autosay("WARNING: Shield generator temperature very high. Recommend reducing load immediately to return shield generator to normal operating temperatures and avoid a possible automatic emergency stop. Any internal damages caused by overheating are NOT covered by your manufacturer's warranty.", "Shield monitor", "Engineering")
+			radio.autosay("WARNING: Shield generator temperature very high. Recommend reducing load immediately to return shield generator to normal operating temperatures and avoid a possible automatic emergency stop. Any internal damages caused by overheating are NOT covered by your manufacturer's warranty.", "Shield monitor", "Command")
 		threshold_alarm = TRUE		//We explicitly set it true here to reset the hysteresis cycles above.
 	if(itt > threshold_high_temperature_cutout)		//critical overheat, shut everything down.
 		if(!threshold_shutdown_alarm)		//Alarm has not sounded, so we'll assume everything is still on. Shut it all down.
-			radio.autosay("WARNING: Shield generator temperature critical. Shield generator shutting down immediately to prevent internal damage.", "Shield Generator monitor", "Engineering")
+			radio.autosay("WARNING: Shield generator temperature critical. Shield generator shutting down immediately to prevent internal damage.", "Shield monitor", "Engineering")
+			radio.autosay("WARNING: Shield generator temperature critical. Shield generator shutting down immediately to prevent internal damage.", "Shield monitor", "Command")
 			threshold_shutdown_alarm = TRUE
 			emergency_shutdown = TRUE
 			offline_for = 300
 			shutdown_field()
-			input_cap = 1		//Negligible input, to allow us to cool.
+			input_cap = 1000		//Negligible input, to allow us to cool.
 	// // // END ECLIPSE EDITS // // //
 
 	if (!anchored)
@@ -553,7 +559,7 @@
 		offline_for += 300 //5 minutes, given that procs happen every 2 seconds
 		shutdown_field()
 		emergency_shutdown = TRUE
-		input_cap = 1		//Eclipse edit: Negligible input, because it's an E-stop!
+		input_cap = 1000		//Eclipse edit: Negligible input, because it's an E-stop!
 		log_event(EVENT_DISABLED, src)
 		if(prob(temp_integrity - 50) * 1.75)
 			spawn()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an issue where shield generator's HTCO won't trigger a second time, and some miscellaneous tweaks.

## Changelog
:cl:
fix: Shield generator high-temperature cutoff now resets properly.
tweak: Shield generator overheat alarm now additionally broadcasts to the command channel.
tweak: Shield generator emergency stop sets the input cap to 1 kW instead of 1 W.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
