### PR TITLE
Bug-fixes and Minor Tweaks

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2907,6 +2907,7 @@
 #include "maps\submaps\planetary_ruins\spider_nest\spider_nest.dm"
 #include "maps\submaps\planetary_ruins\tar_anomaly\tar_anomaly.dm"
 #include "zzz_modular_eclipse\code\datums\autolathe\biomatter.dm"
+#include "zzz_modular_eclipse\code\game\objects\items\weapons\manuals.dm"
 #include "zzz_modular_eclipse\code\game\objects\items\weapons\design_disks\neotheology.dm"
 #include "zzz_modular_eclipse\code\game\turfs\flooring\flooring_decals.dm"
 #include "zzz_modular_eclipse\code\modules\alternate_appearance\alternate_appearance.dm"

--- a/code/datums/outfits/jobs/church.dm
+++ b/code/datums/outfits/jobs/church.dm
@@ -18,7 +18,7 @@
 	suit = /obj/item/clothing/suit/storage/neotheology_coat
 	shoes = /obj/item/clothing/shoes/reinforced
 	gloves = /obj/item/clothing/gloves/thick
-	backpack_contents = list(/obj/item/book/ritual/cruciform/priest = 1, /obj/item/clothing/accessory/cross = 1)
+	backpack_contents = list(/obj/item/book/ritual/cruciform/priest = 1, /obj/item/clothing/accessory/cross = 1, /obj/item/gun/energy/nt_svalinn = 1, /obj/item/cell/small/neotheology = 2)
 
 /decl/hierarchy/outfit/job/church/acolyte
 	name = OUTFIT_JOB_NAME("Children of Mekhane Acolyte")

--- a/code/datums/outfits/jobs/command.dm
+++ b/code/datums/outfits/jobs/command.dm
@@ -9,7 +9,7 @@
 	gloves = /obj/item/clothing/gloves/captain
 	id_type = /obj/item/card/id/gold
 	pda_type = /obj/item/modular_computer/pda/captain
-	backpack_contents = list(/obj/item/storage/box/ids = 1, /obj/item/tool/knife/dagger/ceremonial = 1, /obj/item/clothing/accessory/cross = 1)
+	backpack_contents = list(/obj/item/storage/box/ids = 1, /obj/item/tool/knife/dagger/ceremonial = 1, /obj/item/clothing/accessory/cross = 1, /obj/item/gun/projectile/avasarala = 1, /obj/item/ammo_magazine/magnum/rubber = 2)
 
 /decl/hierarchy/outfit/job/captain/New()
 	..()
@@ -40,7 +40,7 @@
 	gloves = /obj/item/clothing/gloves/thick
 	id_type = /obj/item/card/id/hop
 	pda_type = /obj/item/modular_computer/pda/heads/hop
-	backpack_contents = list(/obj/item/storage/box/ids = 1, /obj/item/tool/knife/dagger/ceremonial = 1, /obj/item/clothing/accessory/cross = 1)
+	backpack_contents = list(/obj/item/storage/box/ids = 1, /obj/item/tool/knife/dagger/ceremonial = 1, /obj/item/clothing/accessory/cross = 1, /obj/item/gun/projectile/avasarala = 1, /obj/item/ammo_magazine/magnum/rubber = 2)
 
 /decl/hierarchy/outfit/job/boff
 	name = OUTFIT_JOB_NAME("Bridge Officer")

--- a/code/datums/outfits/jobs/engineering.dm
+++ b/code/datums/outfits/jobs/engineering.dm
@@ -20,6 +20,7 @@
 	l_ear = /obj/item/device/radio/headset/heads/ce
 	id_type = /obj/item/card/id/ce
 	pda_type = /obj/item/modular_computer/pda/heads/ce
+	backpack_contents = list(/obj/item/gun/projectile/selfload/makarov = 1, /obj/item/ammo_magazine/pistol/rubber = 2)
 
 /decl/hierarchy/outfit/job/engineering/engineer
 	name = OUTFIT_JOB_NAME("Engineer")

--- a/code/datums/outfits/jobs/guild.dm
+++ b/code/datums/outfits/jobs/guild.dm
@@ -11,7 +11,7 @@
 	id_type = /obj/item/card/id/car
 	pda_type = /obj/item/modular_computer/pda/cargo
 	l_ear = /obj/item/device/radio/headset/heads/merchant
-	backpack_contents = list(/obj/item/clipboard = 1) //Eclipse Edit - fixed items not spawning if you spawn in dorms
+	backpack_contents = list(/obj/item/clipboard = 1, /obj/item/gun/projectile/olivaw = 1, /obj/item/ammo_magazine/pistol/rubber = 2) //Eclipse Edit - fixed items not spawning if you spawn in dorms
 
 /decl/hierarchy/outfit/job/cargo/cargo_tech
 	name = OUTFIT_JOB_NAME("Guild Technician")

--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -20,7 +20,7 @@
 	id_type = /obj/item/card/id/cmo
 	pda_type = /obj/item/modular_computer/pda/heads/cmo
 	belt = /obj/item/storage/belt/medical/
-	backpack_contents = list(/obj/item/storage/firstaid/adv = 1) //Eclipse Edit - fixed items not spawning if you spawn in dorms
+	backpack_contents = list(/obj/item/storage/firstaid/adv = 1, /obj/item/gun/projectile/selfload/moebius = 1, /obj/item/ammo_magazine/pistol/rubber = 2) //Eclipse Edit - fixed items not spawning if you spawn in dorms
 
 /decl/hierarchy/outfit/job/medical/doctor
 	name = OUTFIT_JOB_NAME("Medical Doctor")

--- a/code/datums/outfits/jobs/science.dm
+++ b/code/datums/outfits/jobs/science.dm
@@ -18,7 +18,7 @@
 	uniform = /obj/item/clothing/under/rank/expedition_overseer
 	id_type = /obj/item/card/id/rd
 	pda_type = /obj/item/modular_computer/pda/heads/rd
-	backpack_contents = list(/obj/item/oddity/secdocs = 1, /obj/item/clipboard = 1) //Eclipse Edit - fixed items not spawning if you spawn in dorms
+	backpack_contents = list(/obj/item/oddity/secdocs = 1, /obj/item/clipboard = 1, /obj/item/gun/projectile/selfload/moebius = 1, /obj/item/ammo_magazine/pistol/rubber = 2) //Eclipse Edit - fixed items not spawning if you spawn in dorms
 
 /decl/hierarchy/outfit/job/science/scientist
 	name = OUTFIT_JOB_NAME("Scientist")

--- a/code/datums/perks/fate.dm
+++ b/code/datums/perks/fate.dm
@@ -97,8 +97,9 @@
 
 /datum/perk/fate/alcoholic/assign(mob/living/carbon/human/H)
 	..()
-	if(!(/datum/reagent/ethanol in holder.metabolism_effects.addiction_list))
-		var/datum/reagent/R = new /datum/reagent/ethanol
+	var/alcoholtype = pick(subtypesof(/datum/reagent/alcohol))
+	if(!(alcoholtype in holder.metabolism_effects.addiction_list)) //Eclipse Edit - bugfix
+		var/datum/reagent/R = new alcoholtype
 		holder.metabolism_effects.addiction_list.Add(R)
 
 /datum/perk/fate/alcoholic_active

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -23,7 +23,7 @@
 		access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
 		access_moebius, access_engine, access_mining, access_construction, access_mailsorting,
 		access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway,
-		access_external_airlocks, access_change_sec, access_moebius_consoles
+		access_external_airlocks, access_change_sec, access_moebius_consoles, access_armory_consoles, access_sec_consoles
 	)
 
 	stat_modifiers = list(
@@ -83,7 +83,7 @@
 	access = list(
 		access_security, access_moebius, access_medspec, access_engine, access_mailsorting,
 		access_eva, access_sec_doors, access_brig, access_armory, access_maint_tunnels, access_morgue,
-		access_external_airlocks, access_moebius_consoles
+		access_external_airlocks, access_moebius_consoles, access_armory_consoles, access_sec_consoles
 	)
 
 	stat_modifiers = list(
@@ -135,7 +135,7 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/security/inspector
 
-	access = list(access_security, access_moebius, access_medspec, access_engine, access_mailsorting, access_eva, access_sec_doors, access_forensics_lockers, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks, access_moebius_consoles)
+	access = list(access_security, access_moebius, access_medspec, access_engine, access_mailsorting, access_eva, access_sec_doors, access_forensics_lockers, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks, access_moebius_consoles, access_armory_consoles, access_sec_consoles)
 
 	stat_modifiers = list(
 		STAT_BIO = 15,
@@ -190,7 +190,7 @@
 
 	outfit_type = /decl/hierarchy/outfit/job/security/medspec
 
-	access = list(access_security, access_moebius, access_medspec, access_engine, access_mailsorting, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks, access_medical_equip, access_moebius_consoles)
+	access = list(access_security, access_moebius, access_medspec, access_engine, access_mailsorting, access_eva, access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks, access_medical_equip, access_moebius_consoles, access_armory_consoles, access_sec_consoles)
 
 	stat_modifiers = list(
 		STAT_BIO = 25,
@@ -246,7 +246,7 @@
 
 	access = list(
 		access_security, access_moebius, access_engine, access_mailsorting,access_eva,
-		access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks, access_moebius_consoles
+		access_sec_doors, access_brig, access_maint_tunnels, access_morgue, access_external_airlocks, access_moebius_consoles, access_armory_consoles, access_sec_consoles
 	)
 
 	stat_modifiers = list(

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -291,7 +291,7 @@
 
 /obj/item/book/manual/wiki/medical_chemistry
 	name = "Chemistry Textbook"
-	icon_state = "book"//TODO: Add icon
+	icon_state = "chemistry"//Eclipse Edit
 	author = "Medical Journal, volume 2"
 	title = "Chemistry"
 	page_link = "Guide_to_Chemistry_Eclipse" //Eclipse Edit - fixing broken wiki links
@@ -307,7 +307,7 @@
 //service
 /obj/item/book/manual/wiki/barman_recipes
 	name = "Barman Recipes"
-	icon_state = "book"
+	icon_state = "barbook" //Eclipse Edit
 	author = "Sir John Rose"
 	title = "Barman Recipes"
 	page_link = "List_of_Drinking_Recipes_Eclipse" //Eclipse Edit - fixing broken wiki links

--- a/code/game/objects/items/weapons/manuals.dm
+++ b/code/game/objects/items/weapons/manuals.dm
@@ -201,53 +201,53 @@
     			}
 			</script>
 			<p id='loading'>You start skimming through the manual...</p>
-			<iframe width='100%' height='97%' onload="pageloaded(this)" src="[config.wikiurl]/[page_link]_Eris[config.language]?printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
+			<iframe width='100%' height='97%' onload="pageloaded(this)" src="[config.wikiurl]/[page_link][config.language]?printable=yes&remove_links=1" frameborder="0" id="main_frame"></iframe>
 			</body>
 			</html>
 			"}
-
+//Eclipse Edit - fixed broken wiki manual links
 //engineering
 /obj/item/book/manual/wiki/engineering_guide
 	name = "Engineering Textbook"
 	icon_state = "book_engineering"
 	author = "Engineering Encyclopedia"
 	title = "Engineering Textbook"
-	page_link = "Guide_to_Engineering"
+	page_link = "Guide_to_Engineering" //Eclipse Edit - fixing broken wiki links
 
 /obj/item/book/manual/wiki/engineering_construction
 	name = "Ship Repairs and Construction"
 	icon_state = "book_construction"
 	author = "Engineering Encyclopedia"
 	title = "Ship Repairs and Construction"
-	page_link = "Guide_to_Construction"
+	page_link = "Guide_To_Engineering_Eclipse" //Eclipse Edit - fixing broken wiki links
 
 /obj/item/book/manual/wiki/engineering_atmos
 	name = "Pipes and You: Getting To Know Your Scary Tools"
 	icon_state = "book_atmos"
 	author = "Maria Crash, Senior Atmospherics Technician"
 	title = "Pipes and You: Getting To Know Your Scary Tools"
-	page_link = "Guide_to_Atmospherics"
+	page_link = "Guide_to_Atmospherics" //Eclipse Edit - fixing broken wiki links
 
 /obj/item/book/manual/wiki/engineering_hacking
 	name = "Hacking"
 	icon_state = "book_hacking"
 	author = "Engineering Encyclopedia"
 	title = "Hacking"
-	page_link = "Guide_to_Hacking"
+	page_link = "Guide_to_Hacking" //Eclipse Edit - fixing broken wiki links
 
 /obj/item/book/manual/wiki/engineering_singularity
 	name = "Singularity Safety in Special Circumstances"
 	icon_state = "book_singularity"
 	author = "Engineering Encyclopedia"
 	title = "Singularity Safety in Special Circumstances"
-	page_link = "Guide_to_Singularity"
+	page_link = "Guide_to_Singularity" //Eclipse Edit - fixing broken wiki links
 
 /obj/item/book/manual/wiki/engineering_supermatter
 	name = "Supermatter Engine Operating Manual"
 	icon_state = "book_supermatter"
 	author = "Central Engineering Division"
 	title = "Supermatter Engine Operating Manual"
-	page_link = "Guide_to_Supermatter"
+	page_link = "Supermatter_Engine_Eclipse" //Eclipse Edit - fixing broken wiki links
 
 //science
 /obj/item/book/manual/wiki/science_research
@@ -255,14 +255,14 @@
 	icon_state = "book_rnd"
 	author = "Dr. L. Ight"
 	title = "Research and Development 101"
-	page_link = "Guide_to_Research_and_Development"
+	page_link = "Guide_to_Lazarus_Labs_Eclipse" //Eclipse Edit - fixing broken wiki links
 
 /obj/item/book/manual/wiki/science_robotics
 	name = "Cyborgs for Dummies"
 	icon_state = "book_borg"
 	author = "XISC"
 	title = "Cyborgs for Dummies"
-	page_link = "Guide_to_Robotics"
+	page_link = "Guide_to_Robotics" //Eclipse Edit - fixing broken wiki links
 
 //security
 /obj/item/book/manual/wiki/security_ironparagraphs
@@ -271,14 +271,14 @@
 	icon_state = "book_ironparagraphs"
 	author = "Aegis Security"
 	title = "Aegis Laws"
-	page_link = "Laws_Eclipse"
+	page_link = "Laws_Eclipse" //Eclipse Edit - fixing broken wiki links
 
 /obj/item/book/manual/wiki/security_detective
 	name = "The Film Noir: Proper Procedures for Investigations"
 	icon_state = "book_forensics"
 	author = "The Company"
 	title = "The Film Noir: Proper Procedures for Investigations"
-	page_link = "Guide_to_Forensics"
+	page_link = "Guide_to_Forensics" //Eclipse Edit - fixing broken wiki links
 
 //medical
 /obj/item/book/manual/wiki/medical_guide
@@ -287,14 +287,14 @@
 	icon_state = "book_medical"
 	author = "Medical Journal, volume 1"
 	title = "Medical Diagnostics Manual"
-	page_link = "Guide_to_Medical"
+	page_link = "Guide_to_Medicine_Eclipse" //Eclipse Edit - fixing broken wiki links
 
 /obj/item/book/manual/wiki/medical_chemistry
 	name = "Chemistry Textbook"
 	icon_state = "book"//TODO: Add icon
 	author = "Medical Journal, volume 2"
 	title = "Chemistry"
-	page_link = "Guide_to_Chemistry"
+	page_link = "Guide_to_Chemistry_Eclipse" //Eclipse Edit - fixing broken wiki links
 
 //neotheology
 /obj/item/book/manual/wiki/neotheology_cloning //TODO: Completely change this to be NT-oriented.
@@ -302,7 +302,7 @@
 	icon_state = "book"//TODO: Add icon
 	author = "The Church"
 	title = "Cloning Rituals"
-	page_link = "Guide_to_Cloning"
+	page_link = "Guide_to_Cloning" 
 
 //service
 /obj/item/book/manual/wiki/barman_recipes
@@ -310,11 +310,11 @@
 	icon_state = "book"
 	author = "Sir John Rose"
 	title = "Barman Recipes"
-	page_link = "Guide_to_Food_and_Drinks"
+	page_link = "List_of_Drinking_Recipes_Eclipse" //Eclipse Edit - fixing broken wiki links
 
 /obj/item/book/manual/wiki/chef_recipes
 	name = "Chef Recipes"
 	icon_state = "chefbook"
 	author = "Victoria Ponsonby"
 	title = "Chef Recipes"
-	page_link = "Guide_to_Food_and_Drinks"
+	page_link = "List_of_Cooking_Recipes_Eclipse" //Eclipse Edit - fixing broken wiki links

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -123,7 +123,7 @@
 	new /obj/item/clothing/shoes/jackboots/neotheology(src)
 /obj/structure/closet/acolyte
 	name = "acolyte closet"
-	desc = "A closet for those that work with the machines of god."
+	desc = "A closet for those that work with the machines of Mekhane." //Eclipse Edit.
 	icon_state = "acolyte"
 
 /obj/structure/closet/acolyte/populate_contents()
@@ -143,9 +143,6 @@
 	new /obj/item/clothing/suit/storage/neotheosports(src)
 	new /obj/item/clothing/head/armor/acolyte(src)
 	new /obj/item/clothing/suit/armor/acolyte(src)
-	new /obj/item/gun/energy/nt_svalinn(src)
-	new /obj/item/cell/small/neotheology(src)
-	new /obj/item/cell/small/neotheology(src)
 	new /obj/item/storage/belt/sheath(src)
 	new /obj/item/tool/sword/nt/shortsword(src)
 	new /obj/item/tool/knife/dagger/nt(src)

--- a/code/modules/modular_computers/file_system/programs/engineering/shield_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/shield_control.dm
@@ -98,7 +98,7 @@
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)
-		ui = new(user, src, ui_key, "shieldgen.tmpl", src.name, 600, 800, state = state)
+		ui = new(user, src, ui_key, "shieldgen_eclipse.tmpl", src.name, 600, 800, state = state) //Eclipse Edit
 		if(nano_host().update_layout()) // This is necessary to ensure the status bar remains updated along with rest of the UI.
 			ui.auto_update_layout = 1
 		ui.set_initial_data(data)

--- a/code/modules/reagents/metabolism.dm
+++ b/code/modules/reagents/metabolism.dm
@@ -219,7 +219,7 @@
 				if(40 to 50)
 					R.addiction_act_stage4(parent)
 				if(50 to INFINITY)
-					if((parent.stats.getPerk(PERK_ALCOHOLIC) && istype(R, /datum/reagent/ethanol)) || (parent.stats.getPerk(PERK_DRUG_ADDICT) && istype(R, /datum/reagent/stim)))
+					if((parent.stats.getPerk(PERK_ALCOHOLIC) && istype(R, /datum/reagent/alcohol)) || (parent.stats.getPerk(PERK_DRUG_ADDICT) && istype(R, /datum/reagent/stim))) //Eclipse Edit - bugfix
 						R.addiction_act_stage4(parent)
 					else
 						R.addiction_end(parent)

--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -79883,9 +79883,7 @@
 /obj/item/ammo_magazine/srifle,
 /obj/item/ammo_magazine/srifle,
 /obj/machinery/door/blast/shutters/glass{
-	desc = "In case of mutiny, break glass.";
-	id = "Armoury";
-	name = "Armoury showcase"
+	desc = "In case of mutiny, break glass."
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/eris/command/bridge)

--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -11189,6 +11189,14 @@
 /area/eris/security/exerooms)
 "aAz" = (
 /obj/machinery/vending/boozeomat,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/eastleft{
+	dir = 8;
+	req_access = list(28)
+	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "aAA" = (
@@ -63147,11 +63155,10 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/erida/hallway/side/docks)
 "cWI" = (
-/obj/machinery/vending/engivend,
+/obj/machinery/vending/powermat,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/erida/hallway/side/docks)
 "cWJ" = (
-/obj/machinery/vending/powermat,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/erida/hallway/side/docks)
 "cWK" = (

--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -3148,6 +3148,7 @@
 /obj/structure/table/marble,
 /obj/spawner/pizza/low_chance,
 /obj/spawner/pizza/low_chance,
+/obj/item/book/manual/wiki/barman_recipes,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/command/meeting_room)
 "ahc" = (
@@ -6009,6 +6010,7 @@
 "aoe" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/drinks/mug/old_nt,
+/obj/item/book/manual/wiki/agreement,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbreak)
 "aof" = (
@@ -6205,6 +6207,7 @@
 	pixel_x = 4;
 	pixel_y = 3
 	},
+/obj/item/book/manual/wiki/medical_guide,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbreak)
 "aoH" = (
@@ -11701,8 +11704,8 @@
 /area/eris/crew_quarters/bar)
 "aBU" = (
 /obj/structure/table/bar_special,
-/obj/item/book/manual/barman_recipes,
 /obj/item/flame/lighter/zippo,
+/obj/item/book/manual/wiki/barman_recipes,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "aBV" = (
@@ -11740,6 +11743,7 @@
 /obj/structure/table/bar_special,
 /obj/item/reagent_containers/food/drinks/shaker,
 /obj/item/reagent_containers/glass/rag,
+/obj/item/book/manual/wiki/agreement,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "aCc" = (
@@ -15381,6 +15385,7 @@
 /obj/item/reagent_containers/dropper{
 	pixel_y = -4
 	},
+/obj/item/book/manual/wiki/medical_chemistry,
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/rnd/lab)
 "aLa" = (
@@ -16792,6 +16797,7 @@
 	eftpos_name = "Quartermaster EFTPOS scanner"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/book/manual/wiki/agreement,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/office)
 "aOc" = (
@@ -21041,6 +21047,7 @@
 /obj/item/device/scanner/price,
 /obj/item/device/scanner/price,
 /obj/item/device/scanner/price,
+/obj/item/book/manual/wiki/agreement,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/quartermaster/office)
 "aYl" = (
@@ -26407,6 +26414,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/item/book/manual/wiki/agreement,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/security/main)
 "blB" = (
@@ -26415,6 +26423,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/item/book/manual/wiki/agreement,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/security/main)
 "blC" = (
@@ -30467,6 +30476,7 @@
 "buR" = (
 /obj/structure/catwalk,
 /obj/structure/table/standard,
+/obj/item/book/manual/wiki/agreement,
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/breakroom)
 "buS" = (
@@ -30768,6 +30778,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/item/book/manual/wiki/agreement,
+/obj/item/book/manual/wiki/security_ironparagraphs,
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/barracks)
 "bvu" = (
@@ -34067,6 +34079,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/item/book/manual/wiki/agreement,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/warden)
 "bDx" = (
@@ -42643,6 +42656,7 @@
 "bXm" = (
 /obj/structure/table/standard,
 /obj/item/book/manual/wiki/security_ironparagraphs,
+/obj/item/book/manual/wiki/agreement,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/security/brig)
 "bXn" = (
@@ -44528,6 +44542,10 @@
 /turf/simulated/floor/carpet,
 /area/eris/crew_quarters/sleep)
 "cbU" = (
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
+	},
 /turf/simulated/floor/carpet,
 /area/eris/crew_quarters/sleep)
 "cbV" = (
@@ -73201,14 +73219,16 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/sleep)
 "duF" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet,
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/cryopod{
+	dir = 4;
+	icon_state = "cryopod_0";
+	tag = "icon-cryopod_0 (EAST)"
 	},
-/turf/simulated/floor/carpet,
-/area/eris/crew_quarters/sleep)
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel/gray_platform,
+/area/eris/crew_quarters/sleep/cryo)
 "duG" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet,
@@ -74115,6 +74135,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
+/obj/item/book/manual/wiki/agreement,
 /turf/simulated/floor/wood,
 /area/eris/neotheology/chapelritualroom)
 "dwy" = (
@@ -76999,6 +77020,7 @@
 /obj/machinery/camera/network/research{
 	dir = 1
 	},
+/obj/item/book/manual/wiki/agreement,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/rnd/lab)
 "dCh" = (
@@ -77064,6 +77086,7 @@
 /obj/machinery/camera/network/second_section{
 	dir = 8
 	},
+/obj/item/book/manual/wiki/mekhane_guide,
 /turf/simulated/floor/wood,
 /area/eris/neotheology/chapelritualroom)
 "dCn" = (
@@ -79122,6 +79145,12 @@
 /obj/structure/table/standard,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/command/meeting_room)
+"eVO" = (
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
+/turf/simulated/wall/r_wall,
+/area/eris/crew_quarters/sleep/cryo)
 "fbF" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 1;
@@ -79356,6 +79385,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/bar)
+"iDw" = (
+/obj/machinery/cryopod,
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel/gray_platform,
+/area/eris/crew_quarters/sleep/cryo)
 "iQI" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel/bar_dance,
@@ -79486,6 +79522,16 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/propulsion/left)
+"lAO" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/landmark/join/late/cryo,
+/obj/item/device/radio/intercom{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/crew_quarters/sleep/cryo)
 "lBJ" = (
 /obj/structure/cyberplant,
 /obj/machinery/firealarm{
@@ -79559,6 +79605,19 @@
 	},
 /turf/simulated/floor/tiled/steel/danger,
 /area/eris/engineering/propulsion/left)
+"mXX" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/landmark/join/late/cryo,
+/obj/machinery/holoposter{
+	pixel_y = 32
+	},
+/obj/item/device/radio/intercom{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/crew_quarters/sleep/cryo)
 "nbj" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -79702,6 +79761,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/erida/maintenance/sciweapondeck)
+"pxR" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/book/manual/wiki/security_detective,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/eris/security/inspectors_office)
 "pKO" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/medical,
@@ -79896,6 +79962,11 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/neotheology/chapelritualroom)
+"tno" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/chef_recipes,
+/turf/simulated/floor/tiled/cafe,
+/area/eris/crew_quarters/kitchen)
 "tqj" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -79942,6 +80013,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/bar)
+"tJk" = (
+/obj/structure/bookcase,
+/obj/item/book/manual/wiki/engineering_atmos,
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/book/manual/wiki/engineering_guide,
+/obj/item/book/manual/wiki/engineering_hacking,
+/obj/item/book/manual/wiki/engineering_supermatter,
+/turf/simulated/floor/plating/under,
+/area/eris/engineering/breakroom)
 "tTi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/meter,
@@ -79955,6 +80035,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/engineering/long_range_scanner)
+"tWu" = (
+/obj/structure/table/woodentable,
+/obj/item/book/manual/wiki/agreement,
+/turf/simulated/floor/carpet/bcarpet,
+/area/eris/command/meeting_room)
 "uej" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -94591,7 +94676,7 @@ dts
 ajF
 alq
 alD
-alB
+tWu
 aps
 apK
 ahq
@@ -113080,7 +113165,7 @@ aHy
 aHy
 aHy
 aHy
-bsT
+tJk
 btE
 bsT
 brO
@@ -116061,7 +116146,7 @@ awU
 aTO
 aVQ
 aVJ
-aXp
+tno
 aVJ
 byZ
 aTO
@@ -117005,9 +117090,9 @@ dGf
 cDl
 dGf
 cDl
-dGf
-cDl
-dGf
+duF
+eVO
+duF
 cDl
 aNU
 aHy
@@ -117157,9 +117242,9 @@ dGg
 cDl
 dGq
 cDl
-dGg
+mXX
 cDl
-dGg
+lAO
 cDl
 aNU
 aHy
@@ -118525,9 +118610,9 @@ dGh
 cDl
 dGq
 cDl
-dGg
+lAO
 cDl
-dGg
+lAO
 cDl
 aaa
 aaa
@@ -118677,9 +118762,9 @@ dGi
 cDl
 dGr
 cDl
-dGr
+iDw
 cDl
-dGr
+iDw
 cDl
 aav
 aav
@@ -135491,7 +135576,7 @@ bFB
 bBx
 bBx
 bKq
-bNK
+pxR
 bOu
 bPg
 bQa
@@ -164225,7 +164310,7 @@ aav
 aav
 aav
 cbf
-duF
+cbF
 cbU
 cxJ
 cxP
@@ -164236,7 +164321,7 @@ cyq
 cyy
 cyE
 cbU
-duF
+cbF
 cbf
 aav
 aAE
@@ -164681,7 +164766,7 @@ aav
 aav
 aav
 cbf
-duF
+cbF
 cbU
 cxJ
 cxP
@@ -164692,7 +164777,7 @@ cyr
 cyy
 cyE
 cbU
-duF
+cbF
 cbf
 aav
 aAE

--- a/zzz_modular_eclipse/code/game/objects/items/weapons/manuals.dm
+++ b/zzz_modular_eclipse/code/game/objects/items/weapons/manuals.dm
@@ -5,3 +5,10 @@
 	author = "The Northern Light Commission"
 	title = "The Agreement"
 	page_link = "Agreement_Eclipse"
+
+/obj/item/book/manual/wiki/mekhane_guide
+	name = "Guide to Mekhanism"
+	icon_state = "noname"
+	author = "The Children of Mekhane"
+	title = "Guide to Mekhanism"
+	page_link = "Guide_to_Mekhanism_Eclipse" 

--- a/zzz_modular_eclipse/code/game/objects/items/weapons/manuals.dm
+++ b/zzz_modular_eclipse/code/game/objects/items/weapons/manuals.dm
@@ -1,0 +1,7 @@
+/obj/item/book/manual/wiki/agreement
+	name = "The Northern Light Agreement"
+	icon = 'icons/obj/library_vr.dmi'
+	icon_state = "commandguide"
+	author = "The Northern Light Commission"
+	title = "The Agreement"
+	page_link = "Agreement_Eclipse"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Removes Engi-vend from public hall

![image](https://user-images.githubusercontent.com/23348904/168399708-8eff72ed-1b28-463a-aeb2-c1919975f815.png)

- Heads of Staff now get the weapons our changelog says they should have. Fix #1652 
- Fixed Wiki Manuals, All manuals now point to the correct pages. Fix #1626
- added a new wiki manual for The Agreement and a Guide to Mekhane, and I also corrected some of the sprites in the others
- slightly adjusted locations of intercoms in dorms and cryostorage to fix #291
- Fixed Alcoholic perk only selecting Ethanol and nothing else.
- Fixed missing access for security roles to use their consoles.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your Pull Request fixes an issue, please write "Fixes #1234" or "Closes #5678" so the issue automatically closes when the PR is merged. For more information, see Contributing.MD for further information. --->

## Why It's Good For The Game
1. The Engi-Vend is a specific vending machine that is meant to store engineering tools, and be used exclusively by engineers, which is why it dispenses for free. There is already one in the Engineering Break Room, and so two is excessive.
2. Heads of Staff were supposed to get weapons on spawn with the latest upstream merge. The fact that they didn't makes me think there are other changes missing from  that merge, but I don't have time to go through each and every PR and test it right now.
3. Wiki manuals have been broken since the day I joined this server. This finally fixes them (hopefully), If they are broken after this, it's a config problem, and will require Nestor to set the WIKIURL in config.txt to https://eclipse-station.space/wiki/index.php
4. Issue #291 is caused by the intentional code for spawning mobs that tries to grab everything it can off the floor in the tile the mob spawns on and equip it. Easiest way to resolve the issue is to simply move the intercoms away from those spawn points.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new wiki manual for The Agreement
del: Removed Engi-Vend from public space
fix: Fixed Wiki Manuals not loading correct pages
fix: Heads of Staff now receive correct firearms on spawn
tweak: Shield Control program now loads Eclipse shield menu properly
fix: Alcoholic perk now selects random alcohol type instead of just Ethanol
fix: Fixes missing access for Security Consoles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
