### PR TITLE
A balancing pass

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2939,6 +2939,7 @@
 #include "zzz_modular_eclipse\evac_sign\evacsign.dm"
 #include "zzz_modular_eclipse\gunvendor\gunkits.dm"
 #include "zzz_modular_eclipse\maverick_laser_rifle\code\maverick.dm"
+#include "zzz_modular_eclipse\maverick_laser_rifle\code\maverick_diskette.dm"
 #include "zzz_modular_eclipse\maverick_laser_rifle\code\maverick_procs.dm"
 #include "zzz_modular_eclipse\radio_sprites\radio_lockers.dm"
 #include "zzz_modular_eclipse\radio_sprites\radios.dm"

--- a/code/game/gamemodes/events/blob.dm
+++ b/code/game/gamemodes/events/blob.dm
@@ -9,6 +9,8 @@
 	In an emergency, a phoron canister and a lighter will bring a quick end to a blob
 */
 
+#define BLOB_HEATING_POWER 1100
+
 /datum/storyevent/blob
 	id = "blob"
 	name = "Blob"
@@ -68,7 +70,7 @@
 	anchored = TRUE
 	mouse_opacity = 2
 
-	var/maxHealth = 20
+	var/maxHealth = 40		//Eclipse edit: buff blobs a bit.
 	var/health = 1
 	var/health_regen = 1.7
 	var/brute_resist = 1.25
@@ -90,7 +92,7 @@
 	//Expansion gets slower as the blob gets farther away from the origin core
 	var/next_expansion = 0
 	var/coredist = 1
-	var/dist_time_scaling = 1.5
+	var/dist_time_scaling = 1.4875		//Eclipse edit: Speeds up blob growth marginally.
 
 /obj/effect/blob/New(loc, var/obj/effect/blob/_parent)
 	if (_parent)
@@ -200,15 +202,15 @@
 	if(ambient.total_moles)		//Do we even have an atmosphere?
 		var/thermalChange = ambient.get_thermal_energy_change(desired_temperature)
 		var/heat_transfer = 0
-		if(thermalChange > 0)
-			heat_transfer = min(thermalChange , 500)
+		if(thermalChange > 0)		//heating an area
+			heat_transfer = min(thermalChange , BLOB_HEATING_POWER)
 
 			ambient.add_thermal_energy(heat_transfer)
-		else
+		else		//cooling an area
 			thermalChange = abs(thermalChange)
 
 			var/cop = ambient.temperature/T20C
-			heat_transfer = min(thermalChange, cop * 500)	//limit the rate the blob cools a room
+			heat_transfer = min(thermalChange, cop * BLOB_HEATING_POWER)	//limit the rate the blob cools a room
 
 			ambient.add_thermal_energy(-heat_transfer)
 // // // END ECLIPSE EDITS // // //

--- a/code/modules/projectiles/guns/breacher.dm
+++ b/code/modules/projectiles/guns/breacher.dm
@@ -3,7 +3,7 @@
 //There's also a robot version which uses power instead of gas tubes.
 
 /obj/item/hatton
-	name = "Excelsior BT \"Hatton\""
+	name = "\improper Excelsior BT \"Hatton\""
 	desc = "More an instrument than a weapon, this breaching tool was designed for emergency situations."
 	icon = 'icons/obj/guns/breacher.dmi'
 	icon_state = "Hatton_Hammer_1"
@@ -145,7 +145,7 @@
 
 // Magazine
 /obj/item/hatton_magazine
-	name = "Excelsior BT \"Hatton\" gas tube"
+	name = "\improper Excelsior BT \"Hatton\" gas tube"
 	icon = 'icons/obj/guns/breacher.dmi'
 	icon_state = "Hatton_box1"
 	w_class = ITEM_SIZE_SMALL
@@ -203,7 +203,7 @@
 	return
 
 /obj/item/hatton/moebius
-	name = "NanoTrasen BT \"Q-del\""
+	name = "\improper NanoTrasen BT \"Q-del\""
 	desc = {"This breaching tool was reverse engineered from the \"Hatton\" design.
 	Despite the Excelsior \"Hatton\" being traded on the free market through Technomancer League channels,
 	this device suffers from a wide number of reliability issues stemming from it being lathe printed."}

--- a/code/modules/projectiles/guns/energy/crossbow.dm
+++ b/code/modules/projectiles/guns/energy/crossbow.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/energy/crossbow
-	name = "NT EC SC \"Nemesis\"" //Eclipse Edit - gun names standardized
-	desc = "Mini energy crossbow, reverse-engineering by NanoTrasen scientists from a captured schematic. A weapon favored by many mercenary stealth specialists."
+	name = "\improper NT EC SC \"Nemesis\"" //Eclipse Edit - gun names standardized
+	desc = "A mini energy crossbow, reverse-engineered by NanoTrasen scientists from a captured schematic. A weapon favored by many mercenary stealth specialists."
 	icon = 'icons/obj/guns/energy/crossbow.dmi'
 	icon_state = "crossbow"
 	w_class = ITEM_SIZE_SMALL
@@ -25,8 +25,8 @@
 	restrict_safety = TRUE
 
 /obj/item/gun/energy/crossbow/largecrossbow
-	name = "MA EC SC \"Themis\"" //Eclipse Edit - gun names standardized
-	desc = "Energy crossbow, produced by the Mekhanites. A weapon favored by inquisitorial infiltration teams."
+	name = "\improper MA EC SC \"Themis\"" //Eclipse Edit - gun names standardized
+	desc = "An energy crossbow, produced by the Mekhanites. A weapon favored by inquisitorial infiltration teams."
 	icon = 'icons/obj/guns/energy/constantine.dmi'
 	icon_state = "constantine"
 	w_class = ITEM_SIZE_BULKY

--- a/code/modules/projectiles/guns/energy/decloner.dm
+++ b/code/modules/projectiles/guns/energy/decloner.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/decloner
-	name = "Prototype: biological demolecularisor"
+	name = "\improper Prototype: biological demolecularisor"
 	desc = "A gun that discharges high amounts of controlled radiation to slowly break a target into component elements."
 	icon = 'icons/obj/guns/energy/decloner.dmi'
 	icon_state = "decloner"

--- a/code/modules/projectiles/guns/energy/egun.dm
+++ b/code/modules/projectiles/guns/energy/egun.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/energy/gun
-	name = "FS LHG M \"Spider Rose\""  //Eclipse Edit - gun names standardized
-	desc = "Spider Rose is a versatile energy based sidearm, capable of switching between low and high capacity projectile settings. In other words: Stun or Kill."
+	name = "\improper FS LHG M \"Spider Rose\""  //Eclipse Edit - gun names standardized
+	desc = "The Spider Rose is a versatile energy based sidearm, capable of switching between low and high capacity projectile settings. In other words: Stun or Kill."
 	icon = 'icons/obj/guns/energy/egun.dmi'
 	icon_state = "energystun100"
 	item_state = null	//so the human update icon uses the icon_state instead.
@@ -31,8 +31,8 @@
 	spawn_blacklisted = TRUE
 
 /obj/item/gun/energy/gun/martin
-	name = "FS LHG S \"Martin\""  //Eclipse Edit - gun names standardized
-	desc = "Martin is essentialy a downscaled Spider Rose, made for Aegis employees and civilians to use as a personal self defence weapon."
+	name = "\improper FS LHG S \"Martin\""  //Eclipse Edit - gun names standardized
+	desc = "The Martin is essentialy a downscaled Spider Rose, made for Aegis employees and civilians to use as a personal self defence weapon."
 	icon = 'icons/obj/guns/energy/pdw.dmi'
 	icon_state = "PDW"
 	item_state = "gun"

--- a/code/modules/projectiles/guns/energy/floragun.dm
+++ b/code/modules/projectiles/guns/energy/floragun.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/floragun
-	name = "Prototype: floral somatoray"
+	name = "\improper Prototype: floral somatoray"
 	desc = "A tool that discharges controlled radiation which induces mutation in plant cells."
 	icon = 'icons/obj/guns/energy/flora.dmi'
 	icon_state = "floramut100"

--- a/code/modules/projectiles/guns/energy/ionrifle.dm
+++ b/code/modules/projectiles/guns/energy/ionrifle.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/ionrifle
-	name = "NT IR M \"Halicon\"" //Eclipse Edit - gun names standardized
+	name = "\improper NT IR M \"Halicon\"" //Eclipse Edit - gun names standardized
 	desc = "The NT IR Halicon is a man-portable anti-armor weapon designed to disable mechanical threats, produced by NanoTrasen. Not the best of its type, but gets the job done."
 	icon = 'icons/obj/guns/energy/iongun.dmi'
 	icon_state = "ionrifle"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/energy/laser
-	name = "NT LR M \"Lightfall\""  //Eclipse Edit - gun names standardized
-	desc = "\"NanoTrasen\" brand laser rifle based on the highly successful \"Valkyrie\" pattern. Deadly and radiant, like the ire of Capitalism it represents." //Eclipse Edit - description changed
+	name = "\improper NT LR M \"Lightfall\""  //Eclipse Edit - gun names standardized
+	desc = "A \"NanoTrasen\" brand laser rifle based on the highly successful \"Valkyrie\" pattern. Deadly and radiant, like the ire of Capitalism it represents." //Eclipse Edit - description changed
 	icon = 'icons/obj/guns/energy/laser.dmi'
 	icon_state = "laser"
 	item_state = "laser"
@@ -34,7 +34,7 @@
 	spawn_blacklisted = TRUE
 
 /obj/item/gun/energy/laser/mounted/blitz
-	name = "OSDF LR \"Strahl\""  //Eclipse Edit - gun names standardized
+	name = "\improper OSDF LR \"Strahl\""  //Eclipse Edit - gun names standardized
 	desc = "A miniaturized laser rifle, remounted for robotic use only."
 	icon_state = "laser_turret"
 	charge_meter = FALSE
@@ -44,7 +44,7 @@
 	spawn_tags = null
 
 /obj/item/gun/energy/laser/practice
-	name = "NT LR M \"Lightfall\" - P"  //Eclipse Edit - gun names standardized
+	name = "\improper NT LR M \"Lightfall\" - P"  //Eclipse Edit - gun names standardized
 	desc = "A modified version of a \"NanoTrasen\" brand laser rifle, this one fires less concentrated energy bolts, designed for target practice." //Eclipse Edit - description corrected.
 	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_WOOD = 8, MATERIAL_SILVER = 2)
 	price_tag = 1000
@@ -52,7 +52,7 @@
 	zoom_factor = 0
 
 /obj/item/gun/energy/retro
-	name = "OS LR M \"Cog\""  //Eclipse Edit - gun names standardized
+	name = "\improper OS LR M \"Cog\""  //Eclipse Edit - gun names standardized
 	icon = 'icons/obj/guns/energy/retro.dmi'
 	icon_state = "retro"
 	item_state = "retro"
@@ -98,7 +98,7 @@
 	spawn_blacklisted = TRUE
 
 /obj/item/gun/energy/captain
-	name = "NT LCAR SC \"Destiny\""  //Eclipse Edit - gun names standardized
+	name = "\improper NT LCAR SC \"Destiny\""  //Eclipse Edit - gun names standardized
 	icon = 'icons/obj/guns/energy/capgun.dmi'
 	icon_state = "caplaser"
 	item_state = "caplaser"
@@ -124,7 +124,7 @@
 	spawn_blacklisted = TRUE//antag_item_targets
 
 /obj/item/gun/energy/lasercannon
-	name = "Prototype: laser cannon"
+	name = "\improper Prototype: laser cannon"
 	desc = "With the laser cannon, the lasing medium is enclosed in a tube lined with uranium-235 and subjected to high neutron flux in a nuclear reactor core. This incredible technology may help YOU achieve high excitation rates with small laser volumes!"
 	icon = 'icons/obj/guns/energy/lascannon.dmi'
 	icon_state = "lasercannon"
@@ -228,7 +228,7 @@
 		START_PROCESSING(SSobj, src)
 
 /obj/item/gun/energy/psychic/lasercannon
-	name = "Prototype: psychic laser cannon"
+	name = "\improper Prototype: psychic laser cannon"
 	desc = "A laser cannon that attacks the minds of people, causing sanity loss and inducing mental breakdowns."
 	icon = 'icons/obj/guns/energy/psychiccannon.dmi'
 	icon_state = "psychic_lasercannon"
@@ -255,7 +255,7 @@
 	twohanded = FALSE
 
 /obj/item/gun/energy/psychic/mindflayer
-	name = "Prototype: mind flayer"
+	name = "\improper Prototype: mind flayer"
 	desc = "A cruel weapon designed to break the minds of those it targets, causing sanity loss and mental breakdowns."
 	icon = 'icons/obj/guns/energy/xray.dmi'
 	icon_state = "xray"

--- a/code/modules/projectiles/guns/energy/lasersmg.dm
+++ b/code/modules/projectiles/guns/energy/lasersmg.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/lasersmg
-	name = "Disco Vazer \"Lasblender\""
+	name = "\improper Disco Vazer \"Lasblender\""
 	desc = "This conversion of the \"Atreides\" enables it to shoot lasers. Unlike in other laser weapons, the process of creating a laser is based on a chain reaction of localized micro-explosions.\
 			While this method is charge-effective, it worsens accuracy, and the chain-reaction makes the gun always fire in bursts. \
 			Sometimes jokingly called the \"Disco Vazer\"."

--- a/code/modules/projectiles/guns/energy/nt_svalinn.dm
+++ b/code/modules/projectiles/guns/energy/nt_svalinn.dm
@@ -1,7 +1,7 @@
 /obj/item/gun/energy/nt_svalinn
-	name = "NT LHG S \"Svalinn\""  //Eclipse Edit - gun names standardized
+	name = "\improper NT LHG S \"Svalinn\""  //Eclipse Edit - gun names standardized
 
-	desc = "\"Mekhane\" brand laser pistol manufactured by NanoTrasen for use by the Children of Mekhane. Small and easily concealable, it's still a reasonable punch for a laser weapon."
+	desc = "A \"Mekhane\" brand laser pistol manufactured by NanoTrasen for use by the Children of Mekhane. Small and easily concealable, it still packs a reasonable punch for a laser weapon."
 
 	icon = 'icons/obj/guns/energy/nt_svalinn.dmi'
 	icon_state = "nt_svalinn"

--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/nuclear
-	name = "Prototype: advanced energy gun"
+	name = "\improper Prototype: advanced energy gun"
 	desc = "An energy handgun with an experimental miniaturized reactor. Able to fire in two shot bursts."
 	icon = 'icons/obj/guns/energy/nucgun.dmi'
 	icon_state = "nucgun"

--- a/code/modules/projectiles/guns/energy/plasma.dm
+++ b/code/modules/projectiles/guns/energy/plasma.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/plasma
-	name = "NT PR M \"Dominion\""  //Eclipse Edit - gun names standardized
+	name = "\improper NT PR M \"Dominion\""  //Eclipse Edit - gun names standardized
 	desc = "A \"NanoTrasen\" weapon that uses advanced plasma generation technology to emit highly controllable blasts of energized matter. Due to its complexity and cost, it is rarely seen in use, except by specialists."
 	description_info = "Plasma weapons excel at armor penetration, especially with high-power modes due to extreme temperatures they cause."
 	icon = 'icons/obj/guns/energy/pulse.dmi'
@@ -37,14 +37,14 @@
 	spawn_blacklisted = TRUE
 
 /obj/item/gun/energy/plasma/mounted/blitz
-	name = "OSDF PR \"Sprengen\""  //Eclipse Edit - gun names standardized
+	name = "\improper OSDF PR \"Sprengen\""  //Eclipse Edit - gun names standardized
 	desc = "A miniaturized plasma rifle, remounted for robotic use only."
 	icon_state = "plasma_turret"
 	charge_meter = FALSE
 	spawn_tags = null
 
 /obj/item/gun/energy/plasma/destroyer
-	name = "NT PR M \"Purger\""  //Eclipse Edit - gun names standardized
+	name = "\improper NT PR M \"Purger\""  //Eclipse Edit - gun names standardized
 	desc = "A more recent \"NanoTrasen\" brand plasma rifle, developed in direct response to compete against the highly successful \"Cassad\" design. \
             There\'s an inscription on the stock. \'For those whom the Angels hath cursed: thou wilt find, have no one to help.\'"
 	icon = 'icons/obj/guns/energy/destroyer.dmi'
@@ -63,8 +63,8 @@
 
 
 /obj/item/gun/energy/plasma/cassad
-	name = "FS PR M \"Cassad\""  //Eclipse Edit - gun names standardized
-	desc = "\"Frozen Star\" brand energy assault rifle, capable of prolonged combat. When surrender is not an option."
+	name = "\improper FS PR M \"Cassad\""  //Eclipse Edit - gun names standardized
+	desc = "A \"Frozen Star\" brand energy assault rifle, capable of prolonged combat. When surrender is not an option."
 	icon = 'icons/obj/guns/energy/cassad.dmi'
 	icon_state = "cassad"
 	item_state = "cassad"
@@ -87,8 +87,8 @@
 	set_item_state(null, back = TRUE)
 
 /obj/item/gun/energy/plasma/brigador
-	name = "NT PHG S \"Brigador\""  //Eclipse Edit - gun names standardized
-	desc = "\"NanoTrasen\" brand energy pistol, for personal overprotection."
+	name = "\improper NT PHG S \"Brigador\""  //Eclipse Edit - gun names standardized
+	desc = "A \"NanoTrasen\" brand energy pistol, for personal overprotection."
 	icon = 'icons/obj/guns/energy/brigador.dmi'
 	icon_state = "brigador"
 	can_dual = TRUE

--- a/code/modules/projectiles/guns/energy/shrapnel.dm
+++ b/code/modules/projectiles/guns/energy/shrapnel.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/shrapnel
-	name = "OSDF ESG S \"Shellshock\"" //Eclipse Edit - gun names standardized
+	name = "\improper OSDF ESG S \"Shellshock\"" //Eclipse Edit - gun names standardized
 	desc = "An Oberth Republic Strategic Defence Force design, this mat-fab shotgun tends to burn through cells with use. The matter contained in empty cells can be converted directly into ammunition as well, if the safety bolts are loosened." //Eclipse Edit - changed "self defence" to "strategic defence"
 	icon = 'icons/obj/guns/energy/shrapnel.dmi'
 	icon_state = "eshotgun"
@@ -55,7 +55,7 @@
 				to_chat(user, SPAN_NOTICE("You loosen the safety bolts, allowing the weapon to destroy empty cells for use as ammunition."))
 
 /obj/item/gun/energy/shrapnel/mounted
-	name = "OSDF ESG \"Schrapnell\"" //Eclipse Edit - gun names standardized
+	name = "\improper OSDF ESG \"Schrapnell\"" //Eclipse Edit - gun names standardized
 	desc = "An energy-based shotgun, employing a matter fabricator to pull shotgun rounds from thin air and energy."
 	icon_state = "shrapnel"
 	self_recharge = TRUE

--- a/code/modules/projectiles/guns/energy/sniperrifle.dm
+++ b/code/modules/projectiles/guns/energy/sniperrifle.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/energy/sniperrifle
-	name = "NT LDMR M \"Valkyrie\""  //Eclipse Edit - gun names standardized
-	desc = "\"Valkyrie\" is an older NanoTrasen design not in production any longer. A designated marksman rifle capable of shooting powerful ionized beams, this is a weapon for killing from a distance." //Eclipse Edit - altered description
+	name = "\improper NT LDMR M \"Valkyrie\""  //Eclipse Edit - gun names standardized
+	desc = "The \"Valkyrie\" is an older NanoTrasen design not in production any longer. A designated marksman rifle capable of shooting powerful ionized beams, this is a weapon for killing from a distance." //Eclipse Edit - altered description
 	icon = 'icons/obj/guns/energy/sniper.dmi'
 	icon_state = "sniper"
 	item_state = "sniper"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/taser
-	name = "NT SHG M \"Counselor\""  //Eclipse Edit - gun names standardized
+	name = "\improper NT SHG M \"Counselor\""  //Eclipse Edit - gun names standardized
 	desc = "The NT SP \"Counselor\" is a taser gun used for non-lethal takedowns. Used by Nanotrasen security forces before the Corporate Wars." //Eclipse Edit - grammar correction
 	icon = 'icons/obj/guns/energy/taser.dmi'
 	icon_state = "taser"
@@ -25,8 +25,8 @@
 	recharge_time = 10 //Time it takes for shots to recharge (in ticks)
 
 /obj/item/gun/energy/stunrevolver
-	name = "NT SREV S \"Zeus\""  //Eclipse Edit - gun names standardized
-	desc = "Also know as stunrevolver. Older and less precise Nanotrasen solution for non-lethal takedowns. This gun has smaller capacity in exchange for S-cells use."
+	name = "\improper NT SREV S \"Zeus\""  //Eclipse Edit - gun names standardized
+	desc = "Also know as the stun revolver. Older and less precise Nanotrasen solution for non-lethal takedowns. This gun has smaller capacity in exchange for S-cells use."
 	icon = 'icons/obj/guns/energy/stunrevolver.dmi'
 	icon_state = "stunrevolver"
 	item_state = "stunrevolver"

--- a/code/modules/projectiles/guns/energy/toxgun.dm
+++ b/code/modules/projectiles/guns/energy/toxgun.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/energy/toxgun
-	name = "Prototype: phoron pistol"
+	name = "\improper Prototype: phoron pistol"
 	desc = "A specialized firearm designed to fire lethal bolts of phoron."
 	icon = 'icons/obj/guns/energy/toxgun.dmi'
 	icon_state = "toxgun"

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -206,7 +206,7 @@
 	throwforce = 6
 
 /obj/item/gun/launcher/crossbow/RCD
-	name = "\"RXD\" Rapid Crossbow Device" //Eclipse Edit - gun names standardized
+	name = "\improper \"RXD\" Rapid Crossbow Device" //Eclipse Edit - gun names standardized
 	desc = "A hacked together RCD turns an innocent construction tool into the penultimate 'deconstruction' tool. Flashforges projectiles using matter units when the string is drawn back."
 	icon = 'icons/obj/guns/launcher/rxb.dmi'
 	icon_state = "rxb"

--- a/code/modules/projectiles/guns/launcher/projectile_grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/projectile_grenade_launcher.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/shotgun/pump/grenade
-	name = "NT GL \"Protector\""
+	name = "\improper NT GL \"Protector\""
 	desc = "A bulky pump-action grenade launcher. Holds up to 6 grenades in a revolving magazine."
 	icon = 'icons/obj/guns/launcher/riotgun.dmi'
 	icon_state = "riotgun"
@@ -60,7 +60,7 @@
 	twohanded = FALSE
 
 /obj/item/gun/projectile/shotgun/pump/grenade/lenar
-	name = "FS GL \"Lenar\""
+	name = "\improper FS GL \"Lenar\""
 	desc = "A more than bulky pump-action grenade launcher. Holds up to 6 grenades in a revolving magazine."
 	icon = 'icons/obj/guns/launcher/grenadelauncher.dmi'
 	icon_state = "Grenadelauncher_PMC"
@@ -112,7 +112,7 @@
 	unload_underslung(user)
 
 /obj/item/gun/projectile/shotgun/pump/grenade/china
-	name = "China Lake"
+	name = "\improper China Lake"
 	desc = "This centuries-old design was recently rediscovered and adapted for use in modern battlefields. \
 		Working similar to a pump-action combat shotgun, its light weight and robust design quickly made it a popular weapon. \
 		It uses specialised grenade shells."

--- a/code/modules/projectiles/guns/matter/launcher/nt_sprayer.dm
+++ b/code/modules/projectiles/guns/matter/launcher/nt_sprayer.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/matter/launcher/nt_sprayer
-	name = "NT BCR BM \"Street Sprayer\""  //Eclipse Edit - gun names standardized
-	desc = "\"NanoTrasen\" brand cleansing carbine. Uses solid biomass as ammo and dispense cleansing liquid on hit."
+	name = "\improper NT BCR BM \"Street Sprayer\""  //Eclipse Edit - gun names standardized
+	desc = "A \"NanoTrasen\" brand cleansing carbine. Uses solid biomass as ammo and dispense cleansing liquid on hit."
 	icon_state = "nt_sprayer"
 	icon = 'icons/obj/guns/matter/nt_sprayer.dmi'
 	slot_flags = SLOT_BACK | SLOT_BELT

--- a/code/modules/projectiles/guns/matter/launcher/reclaimer.dm
+++ b/code/modules/projectiles/guns/matter/launcher/reclaimer.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/matter/launcher/reclaimer
-	name = "Excelsior \"Reclaimer\""
+	name = "\improper Excelsior \"Reclaimer\""
 	desc = "The weapon of choice for swiftly appropriating matter for communal use. Uses a cellulose based solution to dissolve matter into its original components, not 100% effective."
 	icon_state = "reclaimer"
 	icon = 'icons/obj/guns/matter/reclaimer.dmi'

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -68,7 +68,7 @@
 	I.req_gun_tags = list(GUN_PROJECTILE)
 
 /obj/item/gun_upgrade/barrel/blender
-	name = "OR \"Bullet Blender\" barrel"
+	name = "\improper OR \"Bullet Blender\" barrel"
 	desc = "A curious-looking barrel bearing the Oberth insignia. A small label reads \"No refunds for any collateral damage caused\"."
 	icon_state = "Penetrator"
 	rarity_value = 30
@@ -88,7 +88,7 @@
 
 //For energy weapons, increases the damage output, but also the charge cost. Acquired through loot spawns or Eye of the Protector.
 /obj/item/gun_upgrade/barrel/excruciator
-	name = "NanoTrasen \"EXCRUCIATOR\" giga lens"
+	name = "\improper NanoTrasen \"EXCRUCIATOR\" giga lens"
 	desc = "It's time for us to shine."
 	icon_state = "Excruciator"
 	matter = list(MATERIAL_BIOMATTER = 3, MATERIAL_PLASTEEL = 1, MATERIAL_GOLD = 1, MATERIAL_GLASS = 1)
@@ -109,7 +109,7 @@
 
 //Disables the ability to toggle the safety, toggles the safety permanently off, decreases fire delay. Acquired through loot spawns
 /obj/item/gun_upgrade/trigger/dangerzone
-	name = "Frozen Star \"Danger Zone\" Trigger"
+	name = "\improper Frozen Star \"Danger Zone\" Trigger"
 	desc = "When you need that extra edge."
 	icon_state = "Danger_Zone"
 	rarity_value = 15
@@ -126,7 +126,7 @@
 
 //Disables the ability to toggle the safety, toggles the safety permanently on, takes 2 minutes to remove (yikes). Acquired through loot spawns
 /obj/item/gun_upgrade/trigger/cop_block
-	name = "Frozen Star \"Cop Block\" Trigger"
+	name = "\improper Frozen Star \"Cop Block\" Trigger"
 	desc = "A simpler way of making a weapon display-only"
 	icon_state = "Cop_Block"
 	rarity_value = 15
@@ -142,7 +142,7 @@
 	I.breakable = FALSE
 
 /obj/item/gun_upgrade/trigger/dnalock
-	name = "Frozen Star \"DNA lock\" Trigger"
+	name = "\improper Frozen Star \"DNA lock\" Trigger"
 	desc = "There are many guns, but that one will be yours. Prevents others from using weapon with this trigger."
 	icon_state = "DNA_lock"
 	rarity_value = 15
@@ -163,7 +163,7 @@
 
 //Adds +3 to the internal magazine of a weapon. Acquired through loot spawns.
 /obj/item/gun_upgrade/mechanism/overshooter
-	name = "Frozen Star \"Overshooter\" internal magazine kit"
+	name = "\improper Frozen Star \"Overshooter\" internal magazine kit"
 	desc = "A method of overloading a weapon's internal magazine, fitting more ammunition within the weapon."
 	icon_state = "Overshooter"
 	rarity_value = 20
@@ -179,7 +179,7 @@
 
 //Adds radiation damage to .35 rounds. Acquired through telecrystal uplink
 /obj/item/gun_upgrade/mechanism/glass_widow
-	name = "Syndicate \"Glass Widow\" infuser"
+	name = "\improper Syndicate \"Glass Widow\" infuser"
 	desc = "An illegal modification, used to make formerly useless civilian-grade weaponry into something much more lethal."
 	icon_state = "Glass_Widow"
 	rarity_value = 50
@@ -196,7 +196,7 @@
 
 //Lets the SOL be made into a fully automatic weapon, but increases recoil. Acquirable through Frozen Star Guns&Ammo Vendor
 /obj/item/gun_upgrade/mechanism/weintraub
-	name = "Frozen Star \"Weintraub\" full auto kit"
+	name = "\improper Frozen Star \"Weintraub\" full auto kit"
 	desc = "A fully automatic receiver for rifles"
 	icon_state = "Weintraub"
 	rarity_value = 30
@@ -213,7 +213,7 @@
 
 //Causes your weapon to shoot you in the face, then explode. Acquired through uplink
 /obj/item/gun_upgrade/mechanism/reverse_loader
-	name = "Syndicate reverse loader"
+	name = "\improper Syndicate reverse loader"
 	desc = "Makes bullets loaded into the weapon fire backwards, into its user."
 	icon_state = "Reverse_loader"
 	spawn_blacklisted = TRUE
@@ -229,7 +229,7 @@
 	I.gun_loc_tag = GUN_MECHANISM
 
 /obj/item/storage/box/gun_upgrades
-	name = "Big box of gun fun"
+	name = "\improper Big Box of Gun Fun"
 	desc = "If seen, please report to your nearest \[REDACTED\]"
 	spawn_blacklisted = TRUE
 
@@ -244,7 +244,7 @@
 	new /obj/item/tool_upgrade/augment/ai_tool(src)
 
 /obj/item/gun_upgrade/trigger/boom
-	name = "Syndicate \"Self Destruct\" trigger"
+	name = "\improper Syndicate \"Self Destruct\" trigger"
 	desc = "Trigger that shorts the battery of an energy weapon, causing it to explode when fired."
 	icon_state = "Boom"
 	spawn_blacklisted = TRUE
@@ -263,7 +263,7 @@
 	bad_type = /obj/item/gun_upgrade/scope
 
 /obj/item/gun_upgrade/scope/watchman
-	name = "Frozen Star \"Watchman\" scope"
+	name = "\improper Frozen Star \"Watchman\" scope"
 	desc = "Scope that can be attached to an average gun."
 	icon_state = "Watchman"
 
@@ -278,7 +278,7 @@
 	I.req_gun_tags = list(GUN_SCOPE)
 
 /obj/item/gun_upgrade/scope/killer
-	name = "Syndicate \"Contract Killer\" scope"
+	name = "\improper Syndicate \"Contract Killer\" scope"
 	desc = "Scope used for sniping from large distances."
 	icon_state = "Killer"
 	spawn_blacklisted = TRUE
@@ -314,7 +314,7 @@
 	bad_type = /obj/item/gun_upgrade/cosmetic
 
 /obj/item/gun_upgrade/cosmetic/gold
-	name = "\"Scaramanga\" gold paint"
+	name = "\improper \"Scaramanga\" gold paint"
 	desc = "A small pot of gold paint, for the kingpin in your life."
 	icon_state = "gold_pot"
 	matter = list(MATERIAL_GOLD = 15)
@@ -333,7 +333,7 @@
 //Trash mods, for putting on old guns
 
 /obj/item/gun_upgrade/trigger/faulty
-	name = "Faulty Trigger"
+	name = "faulty trigger"
 	desc = "Weirdly sticky, and none of your fingers seem to fit to it comfortably. This causes more recoil and increases delay between shots as you try to compensate for it."
 	icon_state = "Cop_Block"
 	spawn_blacklisted = TRUE
@@ -351,7 +351,7 @@
 	I.removable = FALSE
 
 /obj/item/gun_upgrade/barrel/faulty
-	name = "Warped Barrel"
+	name = "warped barrel"
 	desc = "Extreme heat has warped this barrel off-target. This decreases the impact force of bullets fired through it and makes it more difficult to correctly aim the weapon it's attached to."
 	icon_state = "Forged_barrel"
 	spawn_blacklisted = TRUE
@@ -370,7 +370,7 @@
 	I.removable = FALSE
 
 /obj/item/gun_upgrade/muzzle/faulty
-	name = "Failed Makeshift Silencer"
+	name = "failed makeshift silencer"
 	desc = "Inspired by cheesy action movies, somebody has left trash on the end of this weapon. This causes the attached weapon to suffer from weaker armor penetration."
 	icon_state = "silencer"
 	spawn_blacklisted = TRUE
@@ -389,7 +389,7 @@
 	I.removable = FALSE
 
 /obj/item/gun_upgrade/mechanism/faulty
-	name = "Unknown Clockwork Mechanism"
+	name = "unknown clockwork mechanism"
 	desc = "It's really not clear what this modification actually does. It appears to effect the attached weapon's recoil, but if it actually helps or hinders the weapon is unclear."
 	icon_state = "Weintraub"
 	spawn_blacklisted = TRUE
@@ -406,7 +406,7 @@
 	I.removable = FALSE
 
 /obj/item/gun_upgrade/scope/faulty
-	name = "Misaligned sights"
+	name = "misaligned sights"
 	desc = "Some bad knocks have changed the angling on the sights of this weapon. This causes the attached weapon to suffer from decreased accuracy."
 	icon_state = "Watchman"
 	spawn_blacklisted = TRUE
@@ -424,7 +424,7 @@
 	I.removable = FALSE
 
 /obj/item/gun_upgrade/trigger/better
-	name = "Refined trigger"
+	name = "refined trigger"
 	desc = "This trigger seems to be made of durable alloys and cut to the precision of milimeters."
 	spawn_blacklisted = TRUE
 	price_tag = 100
@@ -439,7 +439,7 @@
 	I.gun_loc_tag = GUN_TRIGGER
 
 /obj/item/gun_upgrade/barrel/better
-	name = "High-temperature forged barrel"
+	name = "high-temperature forged barrel"
 	desc = "A barrel forged in high temperature, making the metal more resistant."
 	spawn_blacklisted = TRUE
 	price_tag = 150
@@ -454,7 +454,7 @@
 	I.gun_loc_tag = GUN_BARREL
 
 /obj/item/gun_upgrade/muzzle/better
-	name = "Resonance muzzle"
+	name = "resonance muzzle"
 	desc = "A high tech muzzle, made to resonate at the same frequency as the sound that comes from the gun."
 	spawn_blacklisted = TRUE
 	price_tag = 150
@@ -470,7 +470,7 @@
 	I.gun_loc_tag = GUN_MUZZLE
 
 /obj/item/gun_upgrade/mechanism/better
-	name = "Hydraulic mechanism"
+	name = "hydraulic mechanism"
 	desc = "A high tech mechanism that uses hydraulic pumps to keep recoil at a minimum."
 	spawn_blacklisted = TRUE
 	price_tag = 300
@@ -485,7 +485,7 @@
 	I.gun_loc_tag = GUN_MECHANISM
 
 /obj/item/gun_upgrade/scope/better
-	name = "High-res scope"
+	name = "high-res scope"
 	desc = "A high resolution scope"
 	spawn_blacklisted = TRUE
 	price_tag = 100

--- a/code/modules/projectiles/guns/mods/research_mods.dm
+++ b/code/modules/projectiles/guns/mods/research_mods.dm
@@ -3,7 +3,7 @@
 
 //Increases penetration multiplier, projectile speed. Increases fire delay. Acquired via science
 /obj/item/gun_upgrade/barrel/mag_accel
-	name = "Lazarus \"Penetrator\" magnetic accelerator barrel"
+	name = "\improper Lazarus \"Penetrator\" magnetic accelerator barrel"
 	desc = "Uses sympathetic magnetic coiling to increase exit velocity of a metal projectile."
 	icon_state = "Penetrator"
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_PLASTEEL = 1, MATERIAL_GOLD = 1)
@@ -24,7 +24,7 @@
 
 //Adds +10 burn damage to a bullet, lowers armor penetration, adds a constant projectile offset, increases recoil and fire delay. Acquired via science
 /obj/item/gun_upgrade/barrel/overheat
-	name = "Lazarus \"Caster\" magnetic overheat barrel"
+	name = "\improper Lazarus \"Caster\" magnetic overheat barrel"
 	desc = "Uses magnetic induction to heat the projectile of a weapon. Arguable combat effectiveness, but flashy nonetheless."
 	icon_state = "Caster"
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_PLASTEEL = 1, MATERIAL_GOLD = 1)
@@ -47,7 +47,7 @@
 
 // Double damage at the cost of more recoil and a tripled energy consumption
 /obj/item/gun_upgrade/mechanism/battery_shunt
-	name = "Lazarus \"Thunder\" battery shunt"
+	name = "\improper Lazarus \"Thunder\" battery shunt"
 	desc = "This experimental battery shunt is a cutting edge tool attachment which bypasses battery protection circuits to deliver the maximum amount of power in the shortest amount of time."
 	icon_state = "battery_shunt"
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_PLASTEEL = 1, MATERIAL_GOLD = 1, MATERIAL_URANIUM = 1)
@@ -65,7 +65,7 @@
 
 // Greatly increase firerate at the cost of lower damage
 /obj/item/gun_upgrade/mechanism/overdrive
-	name = "Lazarus \"Tesla\" overdrive chip"
+	name = "\improper Lazarus \"Tesla\" overdrive chip"
 	desc = "This experimental chip is a cutting edge tool attachment which bypasses power management protocols to dramatically increase the rate of fire at the cost of a reduced stopping power."
 	icon_state = "overdrive"
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_PLASTEEL = 1, MATERIAL_GOLD = 1, MATERIAL_URANIUM = 1)
@@ -87,7 +87,7 @@
 
 // Add toxin damage to your weapon
 /obj/item/gun_upgrade/barrel/toxin_coater
-	name = "Lazarus \"Black Mamba\" toxin coater"
+	name = "\improper Lazarus \"Black Mamba\" toxin coater"
 	desc = "This experimental barrel coats bullets with a thin layer of toxins just before they leave the weapon. Do not lick it."
 	icon_state = "toxin_coater"
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_PLASTEEL = 1, MATERIAL_GOLD = 2)
@@ -103,7 +103,7 @@
 
 // Add radiation damage to your weapon
 /obj/item/gun_upgrade/barrel/isotope_diffuser
-	name = "Lazarus \"Atomik\" isotope diffuser"
+	name = "\improper Lazarus \"Atomik\" isotope diffuser"
 	desc = "This experimental barrel constantly sprays a thin mist of radioactive isotopes to make projectiles leaving the weapons deadlier. Do not put it in your mouth."
 	icon_state = "isotope_diffuser"
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_PLASTEEL = 1, MATERIAL_URANIUM = 2)
@@ -119,7 +119,7 @@
 
 // Add psy damage to your weapon
 /obj/item/gun_upgrade/mechanism/psionic_catalyst
-	name = "Lazarus \"Mastermind\" psionic catalyst"
+	name = "\improper Lazarus \"Mastermind\" psionic catalyst"
 	desc = "This controversial device greatly amplifies the natural psionic ability of the user and allows them to project their will into the world. Before the development of the Psi Amp, psionic disciplines were mostly detectable only in a lab environment."
 	icon_state = "psionic_catalyst"
 	matter = list(MATERIAL_SILVER = 3, MATERIAL_PLASTEEL = 3, MATERIAL_URANIUM = 3)
@@ -134,8 +134,8 @@
 	I.gun_loc_tag = GUN_MECHANISM
 
 /obj/item/gun_upgrade/barrel/gauss
-	name = "Syndicate \"Gauss Coil\" barrel"
-	desc = "Make bullet pierce through wall and penetrate armors easily, but losing rate of fire and increece recoil."
+	name = "\improper Syndicate \"Gauss Coil\" barrel"
+	desc = "Makes bullets pierce through walls and penetrate armor easily, but at the cost of a lower rate of fire and increased recoil."	//Eclipse edit: Grammar
 	icon_state = "Gauss"
 	spawn_blacklisted = TRUE
 

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -108,6 +108,8 @@
 	gun_parts = list(/obj/item/part/gun/frame/ak47 = 1, /obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/lrifle = 1)
 
 	price_tag = 3500
+	
+	simplemob_bonus_damage_multiplier = 0.2 //Eclipse edit: Balancing.
 
 /obj/item/gun/projectile/automatic/ak47/sa/CtrlShiftClick(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/projectile/automatic/ak47.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/ak47.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/ak47
-	name = "EX AR .30 \"AKMS\""  //Eclipse Edit - gun names standardized
+	name = "\improper EX AR .30 \"AKMS\""  //Eclipse Edit - gun names standardized
 	desc = "Weapon of the oppressed, oppressors, and extremists of all flavours. \
 		 This is a copy of an ancient semi-automatic rifle chambered for .30 Rifle. If it won't fire, percussive maintenance should get it working again. \
 		 It is known for its easy maintenance, and low price. This gun is not in active military service anymore, but has become ubiquitous among criminals and insurgents. \
@@ -38,7 +38,7 @@
 	var/folded = FALSE
 
 /obj/item/part/gun/frame/ak47
-	name = "AK frame"
+	name = "\improper AK frame"
 	desc = "An AK rifle frame. The eternal firearm."
 	icon_state = "frame_ak"
 	matter = list(MATERIAL_PLASTEEL = 8)
@@ -90,7 +90,7 @@
 //////////////////////////////////////////SA//////////////////////////////////////////
 
 /obj/item/gun/projectile/automatic/ak47/sa
-	name = "SA CAR .30 \"Krinkov\""					// US nickname for AKSu - Eclipse Edit - gun names standardized
+	name = "\improper SA CAR .30 \"Krinkov\""					// US nickname for AKSu - Eclipse Edit - gun names standardized
 	desc = "Weapon of the oppressed, oppressors, and extremists of all flavours. \
 			This is a copy of an ancient semi-automatic rifle chambered for .30 Rifle. If it won't fire, percussive maintenance should get it working again. \
 			It is known for its easy maintenance, and low price. This gun is not in active military service anymore, but has become ubiquitous among criminals and insurgents. \
@@ -153,7 +153,7 @@
 //////////////////////////////////////////FS//////////////////////////////////////////
 
 /obj/item/gun/projectile/automatic/ak47/fs
-	name = "FS AR .30 \"Vipr\""						// Vipr like a play on Viper and Vepr
+	name = "\improper FS AR .30 \"Vipr\""						// Vipr like a play on Viper and Vepr
 	desc = "Weapon of the oppressed, oppressors, and extremists of all flavours. \
 			This is a copy of an ancient semi-automatic rifle chambered for .30 Rifle. If it won't fire, percussive maintenance should get it working again. \
 			It is known for its easy maintenance, and low price. This gun is not in active military service anymore, but has become ubiquitous among criminals and insurgents. \
@@ -183,7 +183,7 @@
 //////////////////////////////////////////IH//////////////////////////////////////////
 
 /obj/item/gun/projectile/automatic/ak47/fs/ih
-	name = "FS AR .30 \"Venger\""						// From a song
+	name = "\improper FS AR .30 \"Venger\""						// From a song
 	desc = "Weapon of the oppressed, oppressors, and extremists of all flavours. \
 			This is a copy of an ancient semi-automatic rifle chambered for .30 Rifle. If it won't fire, percussive maintenance should get it working again. \
 			It is known for its easy maintenance, and low price. This gun is not in active military service anymore, but has become ubiquitous among criminals and insurgents. \
@@ -236,7 +236,7 @@
 //////////////////////////////////////////Makeshift//////////////////////////////////////////
 
 /obj/item/gun/projectile/automatic/ak47/makeshift
-	name = "Makeshift AR .30 \"Kalash\""
+	name = "makeshift AR .30 \"Kalash\""
 	desc = "Weapon of the oppressed, oppressors, and extremists of all flavours. \
 			This is a copy of an ancient semi-automatic rifle chambered for .30 Rifle. If it won't fire, percussive maintenance should get it working again. \
 			It is known for its easy maintenance, and low price. This gun is not in active military service anymore, but has become ubiquitous among criminals and insurgents. \

--- a/code/modules/projectiles/guns/projectile/automatic/atreides.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/atreides.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/atreides
-	name = "FS SMG .35 Auto \"Atreides\""
+	name = "\improper FS SMG .35 Auto \"Atreides\""
 	desc = "The Atreides is a replica of an old and popular SMG. Cheap and mass produced generic self-defence weapon. \
 			The overall design is so generic that it is neither considered good nor bad in comparison to other firearms. \
 			Uses .35 Auto rounds."

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/c20r
-	name = "S SMG .35 Auto \"C-20r\""  //Eclipse Edit - gun names standardized
+	name = "\improper S SMG .35 Auto \"C-20r\""  //Eclipse Edit - gun names standardized
 	desc = "The C-20r is a lightweight and robust bullpup SMG of ancient design, for when you REALLY need someone dead. \
 			Famous as most popular SMG used by criminal organizations of various sorts. Was recently reverse-engineered by NanoTrasen \
 			almost completely from the scratch, introducing this gun to a broad mass of new customers. \
@@ -38,7 +38,7 @@
 
 
 /obj/item/part/gun/frame/c20r
-	name = "C20r frame"
+	name = "\improper C20r frame"
 	desc = "A C20r SMG frame. The syndicate's bread and butter."
 	icon_state = "frame_syndi"
 	result = /obj/item/gun/projectile/automatic/c20r
@@ -62,7 +62,7 @@
 	update_icon()
 
 /obj/item/gun/projectile/automatic/c20r/moebius
-	name = "LF SMG .35 Auto \"C-20m\""  //Eclipse Edit - gun names standardized
+	name = "\improper LF SMG .35 Auto \"C-20m\""  //Eclipse Edit - gun names standardized
 	desc = "The C-20m is a Lazarus Foundation copy of the infamous C-20r, a lightweight and robust bullpup SMG of ancient design. \
 			Famous as the most popular SMG used by criminal organizations of various sorts. Uses .35 Auto rounds." //Eclipse Edit - spelling/grammar
 	icon = 'icons/obj/guns/projectile/c20m.dmi'
@@ -73,7 +73,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/c20r/moebius = 1, /obj/item/part/gun/grip/black = 1, /obj/item/part/gun/mechanism/smg = 1, /obj/item/part/gun/barrel/pistol = 1)
 
 /obj/item/part/gun/frame/c20r/moebius
-	name = "C-20M frame"
+	name = "\improper C-20M frame"
 	desc = "A C-20M SMG frame. The syndicate's bread and butter, reverse-engineered."
 	icon_state = "frame_moe"
 	result = /obj/item/gun/projectile/automatic/c20r/moebius

--- a/code/modules/projectiles/guns/projectile/automatic/c20r.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/c20r.dm
@@ -71,6 +71,8 @@
 	damage_multiplier = 1	//Not quite as good as real syndi
 	penetration_multiplier = 1.2 //12 with lethal, 24 with HV
 	gun_parts = list(/obj/item/part/gun/frame/c20r/moebius = 1, /obj/item/part/gun/grip/black = 1, /obj/item/part/gun/mechanism/smg = 1, /obj/item/part/gun/barrel/pistol = 1)
+	
+	simplemob_bonus_damage_multiplier = 0.15 //Eclipse edit: Balancing.
 
 /obj/item/part/gun/frame/c20r/moebius
 	name = "\improper C-20M frame"

--- a/code/modules/projectiles/guns/projectile/automatic/dallas.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/dallas.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/dallas //it's a good way to die
-	name = "PAR .25 CS \"Dallas\""
+	name = "\improper PAR .25 CS \"Dallas\""
 	desc = "Dallas is a pulse-action air-cooled automatic assault rifle made by unknown manufacturer. This weapon is very rare, but deadly efficient. \
 			It's used by elite mercenaries, assassins or bald marines. Uses .25 Caseless rounds."
 	icon = 'icons/obj/guns/projectile/dallas.dmi'
@@ -45,7 +45,7 @@
 	return
 
 /obj/item/part/gun/frame/dallas
-	name = "Dallas frame"
+	name = "\improper Dallas frame"
 	desc = "A Dallas pulse rifle frame. Sawing aliens in twain since time immemorial."
 	icon_state = "frame_dallas"
 	result = /obj/item/gun/projectile/automatic/dallas

--- a/code/modules/projectiles/guns/projectile/automatic/drozd.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/drozd.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/drozd
-	name = "EX SMG .40 Magnum \"Drozd\""  //Eclipse Edit - gun names standardized
+	name = "\improper EX SMG .40 Magnum \"Drozd\""  //Eclipse Edit - gun names standardized
 	desc = "An excellent fully automatic Heavy SMG. Rifled to take a larger caliber than a typical submachine gun, but unlike \
 			other heavy SMGs this one makes use of its increased caliber to achieve excellent armor penetration capabilities. \
 			Suffers a bit less from poor recoil control and has a lower than average fire rate. Uses .40 Magnum rounds." //Eclipse Edit - spelling/grammar
@@ -43,7 +43,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/drozd
-	name = "Drozd frame"
+	name = "\improper Drozd frame"
 	desc = "A Drozd SMG frame. Workhorse of the Excelsior force."
 	icon_state = "frame_excelsmg"
 	result = /obj/item/gun/projectile/automatic/drozd

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/lmg
-	name = "LMG .30 \"L6 SAW\""  //Eclipse Edit - gun names standardized
+	name = "\improper LMG .30 \"L6 SAW\""  //Eclipse Edit - gun names standardized
 	desc = "A rather traditionally made L6 SAW with a pleasantly lacquered wooden pistol grip. This one is unmarked."
 	icon = 'icons/obj/guns/projectile/l6.dmi'
 	var/icon_base = "l6"
@@ -90,7 +90,7 @@
 
 
 /obj/item/gun/projectile/automatic/lmg/pk
-	name = "SA LMG .30 \"Pulemyot Kalashnikova\""  //Eclipse Edit - gun names standardized
+	name = "\improper SA LMG .30 \"Pulemyot Kalashnikova\""  //Eclipse Edit - gun names standardized
 	desc = "\"Kalashnikov's Machinegun\", a well preserved and maintained antique weapon of war."
 	icon = 'icons/obj/guns/projectile/pk.dmi'
 	icon_base = "pk"
@@ -100,7 +100,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/pk = 1, /obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/machinegun = 1, /obj/item/part/gun/barrel/lrifle = 1)
 
 /obj/item/part/gun/frame/pk
-	name = "Pulemyot Kalashnikova frame"
+	name = "\improper Pulemyot Kalashnikova frame"
 	desc = "A Pulemyot Kalashnikova LMG frame. A violent and beautiful spark of the past."
 	icon_state = "frame_pk"
 	result = /obj/item/gun/projectile/automatic/lmg/pk
@@ -115,7 +115,7 @@
 
 
 /obj/item/gun/projectile/automatic/lmg/tk
-	name = "FS LMG .30 \"Takeshi\""  //Eclipse Edit - gun names standardized
+	name = "\improper FS LMG .30 \"Takeshi\""  //Eclipse Edit - gun names standardized
 	desc = "The \"Takeshi LMG\" is FS's answer to PMC's needs for mass supression and meat grinding, a fine oiled machine of war and death."
 	icon = 'icons/obj/guns/projectile/tk.dmi'
 	icon_base = "tk"
@@ -128,7 +128,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/tk = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/machinegun = 1, /obj/item/part/gun/barrel/lrifle = 1)
 
 /obj/item/part/gun/frame/tk
-	name = "Takeshi frame"
+	name = "\improper Takeshi frame"
 	desc = "A Takeshi LMG frame. A fine-oiled machine of war and death."
 	icon_state = "frame_mg"
 	result = /obj/item/gun/projectile/automatic/lmg/tk

--- a/code/modules/projectiles/guns/projectile/automatic/luty.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/luty.dm
@@ -15,6 +15,8 @@
 	ammo_type = /obj/item/ammo_casing/pistol
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_PISTOL|MAG_WELL_H_PISTOL|MAG_WELL_SMG
+	
+	simplemob_bonus_damage_multiplier = 0.4 //Eclipse edit: Balancing.
 
 	init_firemodes = list(
 		FULL_AUTO_400,

--- a/code/modules/projectiles/guns/projectile/automatic/maxim.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/maxim.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/projectile/automatic/maxim
 	bad_type = /obj/item/gun/projectile/automatic/maxim
-	name = "EX HMG .30 \"Maxim\""  //Eclipse Edit - gun names standardized
+	name = "\improper EX HMG .30 \"Maxim\""  //Eclipse Edit - gun names standardized
 	desc = "A bulky yet versatile gun, the Maxim has been used in ships, turrets, and by hand."
 	icon = 'icons/obj/guns/projectile/maxim.dmi'
 	icon_state = "maxim"
@@ -57,7 +57,7 @@
 	set_item_state(itemstring)
 
 /obj/item/part/gun/frame/maxim
-	name = "Maxim frame"
+	name = "\improper Maxim frame"
 	desc = "A Maxim HMG frame. Whatever happens, we have got the Maxim gun and they have not."
 	icon_state = "frame_maxim"
 	result = /obj/item/gun/projectile/automatic/maxim

--- a/code/modules/projectiles/guns/projectile/automatic/molly.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/molly.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/molly
-	name = "FS MP .35 Auto \"Molly\""
+	name = "\improper FS MP .35 Auto \"Molly\""
 	desc = "An experimental fully automatic pistol, designed as a middle ground between SMGs and Pistols. \
 			Primarily employed in CQC scenarios or as a civilian self defence tool. \
 			Takes both highcap pistol and smg mags. Uses .35 Auto rounds."
@@ -65,7 +65,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/molly
-	name = "Molly frame"
+	name = "\improper Molly frame"
 	desc = "A Molly machine pistol frame. Toeing the line between pistol and SMG."
 	icon_state = "frame_autopistol"
 	result = /obj/item/gun/projectile/automatic/molly

--- a/code/modules/projectiles/guns/projectile/automatic/molly.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/molly.dm
@@ -37,6 +37,8 @@
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 	wield_delay = 0 // pistols don't get delays. X Doubt
 	gun_parts = list(/obj/item/part/gun/frame/molly = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/pistol = 1, /obj/item/part/gun/barrel/pistol = 1)
+	
+	simplemob_bonus_damage_multiplier = 0.25 //Eclipse edit: Balancing.
 
 /obj/item/gun/projectile/automatic/molly/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/automatic/slaught_o_matic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/slaught_o_matic.dm
@@ -19,6 +19,8 @@
 	price_tag = 100
 	rarity_value = 40
 	gun_parts = list(/obj/item/stack/material/plastic = 2)
+	
+	simplemob_bonus_damage_multiplier = 0.35 //Eclipse edit: Balancing.
 
 	safety = FALSE
 	auto_eject_sound = 'sound/weapons/smg_empty_alarm.ogg'

--- a/code/modules/projectiles/guns/projectile/automatic/slaught_o_matic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/slaught_o_matic.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/slaught_o_matic
-	name = "FS HG .35 Auto \"Slaught-o-Matic\""
+	name = "\improper FS HG .35 Auto \"Slaught-o-Matic\""
 	desc = "This disposable plastic handgun is mass-produced by Frozen Star for civilian use. It often is used by street urchin, thugs, or terrorists on a budget. For what it's worth, it's not an awful handgun - but you only get one magazine before the gun locks up and becomes useless."
 	icon = 'icons/obj/guns/projectile/slaught_o_matic.dmi'
 	icon_state = "slaught"

--- a/code/modules/projectiles/guns/projectile/automatic/sol.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sol.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/sol
-	name = "FS CAR .25 CS \"Sol\""
+	name = "\improper FS CAR .25 CS \"Sol\""
 	desc = "A standard-issue weapon used by Aegis operatives. Compact and reliable. Uses .25 Caseless rounds."
 	icon = 'icons/obj/guns/projectile/sol.dmi'
 	icon_state = "sol"

--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -32,6 +32,8 @@
 
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 	gun_parts = list(/obj/item/part/gun/frame/straylight = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/smg = 1, /obj/item/part/gun/barrel/pistol = 1)
+	
+	simplemob_bonus_damage_multiplier = 0.3 //Eclipse edit: Balancing.
 
 /obj/item/gun/projectile/automatic/straylight/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/automatic/straylight.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/straylight.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/straylight
-	name = "FS SMG .35 Auto \"Straylight\""
+	name = "\improper FS SMG .35 Auto \"Straylight\""
 	desc = "A compact, lightweight and cheap rapid-firing submachine gun. In the past it was primarily used for testing ammunition and weapon modifications, \
 			nowadays it is mass-produced for Aegis security forces. Suffers from poor recoil control and underperforming ballistic impact, \
 			but makes up for this through sheer firerate. Especially effective with rubber ammunition. Uses .35 Auto rounds." //Eclipse Edit - spelling / grammar
@@ -58,7 +58,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/straylight
-	name = "Straylight frame"
+	name = "\improper Straylight frame"
 	desc = "A Straylight SMG frame. A rabidly fast bullet hose."
 	icon_state = "frame_ihsmg"
 	result = /obj/item/gun/projectile/automatic/straylight

--- a/code/modules/projectiles/guns/projectile/automatic/sts35.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/sts35.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/sts35
-	name = "OSDF AR .30 \"STS-35\"" //Eclipse Edit - gun names standardized
+	name = "\improper OSDF AR .30 \"STS-35\"" //Eclipse Edit - gun names standardized
 	desc = "The rugged STS-35 is a durable automatic weapon, made by Oberth Republic Strategic Defence Force. \
 			Extremely efficient rifle design that was put in service right before collapse of the Republic, this weapon can be found almost anywhere in the galaxy by now. \
 			Uses .30 Rifle rounds." //Eclipse Edit - self defence renamed strategic defence
@@ -54,7 +54,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/sts35
-	name = "STS-35 frame"
+	name = "\improper STS-35 frame"
 	desc = "An STS-35 frame. The finest in kraut space magic."
 	icon_state = "frame_orrifle"
 	result = /obj/item/gun/projectile/automatic/sts35

--- a/code/modules/projectiles/guns/projectile/automatic/type17.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/type17.dm
@@ -31,6 +31,8 @@
     spawn_blacklisted = TRUE //until loot rework
 
     gun_tags = list(GUN_SILENCABLE)
+	
+	simplemob_bonus_damage_multiplier = 0.1 //Eclipse edit: Balancing.
 
 /obj/item/gun/projectile/automatic/type_17/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/automatic/type17.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/type17.dm
@@ -1,36 +1,36 @@
 /obj/item/gun/projectile/automatic/type_17
-    name = "\improper OS AR .20 \"Type XVII\""
-    desc = "An old Onestar assault rifle. A reliable, if unintuitive, design. Uses .20 Rifle magazines."
-    icon = 'icons/obj/guns/projectile/os/type_17.dmi'
-    icon_state = "type_17"
-    item_state = "type_17"
-    w_class = ITEM_SIZE_HUGE
-    force = WEAPON_FORCE_PAINFUL
-    caliber = CAL_SRIFLE
-    origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 1)
-    slot_flags = SLOT_BACK
-    load_method = MAGAZINE
-    mag_well = MAG_WELL_RIFLE
-    magazine_type = /obj/item/ammo_magazine/srifle
-    matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLATINUM = 8, MATERIAL_PLASTIC = 10)
-    price_tag = 3800
-    fire_sound = 'sound/weapons/guns/fire/cal/20.ogg'
-    unload_sound = 'sound/weapons/guns/interact/ltrifle_magout.ogg'
-    reload_sound = 'sound/weapons/guns/interact/ltrifle_magin.ogg'
-    cocked_sound = 'sound/weapons/guns/interact/ltrifle_cock.ogg'
-    zoom_factor = 0.6
-    recoil_buildup = 1.5
-    one_hand_penalty = 15 //automatic rifle level
-    damage_multiplier = 1.3
-    penetration_multiplier = 1.7
-    spawn_tags = SPAWN_TAG_GUN_OS
-    init_firemodes = list(
+	name = "\improper OS AR .20 \"Type XVII\""
+	desc = "An old Onestar assault rifle. A reliable, if unintuitive, design. Uses .20 Rifle magazines."
+	icon = 'icons/obj/guns/projectile/os/type_17.dmi'
+	icon_state = "type_17"
+	item_state = "type_17"
+	w_class = ITEM_SIZE_HUGE
+	force = WEAPON_FORCE_PAINFUL
+	caliber = CAL_SRIFLE
+	origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 1)
+	slot_flags = SLOT_BACK
+	load_method = MAGAZINE
+	mag_well = MAG_WELL_RIFLE
+	magazine_type = /obj/item/ammo_magazine/srifle
+	matter = list(MATERIAL_PLASTEEL = 20, MATERIAL_PLATINUM = 8, MATERIAL_PLASTIC = 10)
+	price_tag = 3800
+	fire_sound = 'sound/weapons/guns/fire/cal/20.ogg'
+	unload_sound = 'sound/weapons/guns/interact/ltrifle_magout.ogg'
+	reload_sound = 'sound/weapons/guns/interact/ltrifle_magin.ogg'
+	cocked_sound = 'sound/weapons/guns/interact/ltrifle_cock.ogg'
+	zoom_factor = 0.6
+	recoil_buildup = 1.5
+	one_hand_penalty = 15 //automatic rifle level
+	damage_multiplier = 1.3
+	penetration_multiplier = 1.7
+	spawn_tags = SPAWN_TAG_GUN_OS
+	init_firemodes = list(
 		BURST_3_ROUND,
-        SEMI_AUTO_NODELAY
+		SEMI_AUTO_NODELAY
 		)
-    spawn_blacklisted = TRUE //until loot rework
+	spawn_blacklisted = TRUE //until loot rework
 
-    gun_tags = list(GUN_SILENCABLE)
+	gun_tags = list(GUN_SILENCABLE)
 	
 	simplemob_bonus_damage_multiplier = 0.1 //Eclipse edit: Balancing.
 

--- a/code/modules/projectiles/guns/projectile/automatic/type17.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/type17.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/type_17
-    name = "OS AR .20 \"Type XVII\""
+    name = "\improper OS AR .20 \"Type XVII\""
     desc = "An old Onestar assault rifle. A reliable, if unintuitive, design. Uses .20 Rifle magazines."
     icon = 'icons/obj/guns/projectile/os/type_17.dmi'
     icon_state = "type_17"

--- a/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/vintorez.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/vintorez
-	name = "EX DMR .20 \"Vintorez\"" //Eclipse Edit - gun names standardized
+	name = "\improper EX DMR .20 \"Vintorez\"" //Eclipse Edit - gun names standardized
 	desc = "This gun is a copy of a design from a country that no longer exists. It is still highly prized for its armor piercing capabilities. \
 			The design was made to be able to fit long magazine alongside the standard ones."
 	icon = 'icons/obj/guns/projectile/vintorez.dmi'
@@ -45,7 +45,7 @@
 	item_state = itemstring
 
 /obj/item/part/gun/frame/vintorez
-	name = "Vintorez frame"
+	name = "\improper Vintorez frame"
 	desc = "A Vintorez rifle frame. Accurate and damaging."
 	icon_state = "frame_vintorez"
 	result = /obj/item/gun/projectile/automatic/vintorez

--- a/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
@@ -36,6 +36,7 @@
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 	gun_parts = list(/obj/item/part/gun/frame/wintermute = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/srifle = 1)
 
+	simplemob_bonus_damage_multiplier = 0.05 //Eclipse edit: Balancing.
 
 /obj/item/gun/projectile/automatic/wintermute/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/wintermute.dm
@@ -1,7 +1,7 @@
 /obj/item/gun/projectile/automatic/wintermute
-	name = "FS AR .20 \"Wintermute\""
+	name = "\improper FS AR .20 \"Wintermute\""
 	desc = "A high end military grade assault rifle, designed as a modern ballistic infantry weapon. Primarily used by and produced for soldiers. Uses .20 Rifle magazines. \
-			The design was made to be able to fit long magazine alongside the standard ones."
+			The design was made to be able to fit long magazines alongside the standard ones."
 	icon = 'icons/obj/guns/projectile/wintermute.dmi'
 	icon_state = "wintermute"
 	item_state = "wintermute"
@@ -60,7 +60,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/wintermute
-	name = "Wintermute frame"
+	name = "\improper Wintermute frame"
 	desc = "A Wintermute assault rifle frame. The finest of the Aegis lineup."
 	icon_state = "frame_wintermute"
 	result = /obj/item/gun/projectile/automatic/wintermute

--- a/code/modules/projectiles/guns/projectile/automatic/z8.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/z8.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/z8
-	name = "OSDF CAR .20 \"Z8 Bulldog\""
+	name = "\improper OSDF CAR .20 \"Z8 Bulldog\""
 	desc = "The Z8 Bulldog is an older bullpup carbine model, made by the \"Oberth Republic Strategic Defence Force\". It includes an underbarrel grenade launcher which is compatible with most modern grenade types. Uses .20 Rifle rounds." //Eclipse Edit - self defence renamed strategic defence
 	icon = 'icons/obj/guns/projectile/carabine.dmi'
 	icon_state = "z8"
@@ -90,7 +90,7 @@
 		to_chat(user, "\The [launcher] is empty.")
 
 /obj/item/part/gun/frame/z8
-	name = "Z8 Bulldog frame"
+	name = "\improper Z8 Bulldog frame"
 	desc = "A Z8 Bulldog carbine frame. Old but gold."
 	icon_state = "frame_pug"
 	result = /obj/item/gun/projectile/automatic/z8

--- a/code/modules/projectiles/guns/projectile/automatic/z8.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/z8.dm
@@ -25,6 +25,8 @@
 	zoom_factor = 0.2
 	one_hand_penalty = 10 //bullpup rifle level
 	gun_tags = list(GUN_FA_MODDABLE)
+	
+	simplemob_bonus_damage_multiplier = 0.1 //Eclipse edit: Balancing.
 
 	init_firemodes = list(
 		SEMI_AUTO_NODELAY,

--- a/code/modules/projectiles/guns/projectile/automatic/zoric.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/zoric.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/zoric
-	name = "SA SMG .40 Magnum \"Zoric\""
+	name = "\improper SA SMG .40 Magnum \"Zoric\""
 	desc = "A Heavy Submachine Gun made by \"Serbian Arms\", for paramilitary and private security use. \
 			Rifled to take a larger caliber than a typical submachine gun, it boasts a greater impact, but suffers \
 			from poor recoil control and worse than average armor penetration capabilities as a result. \
@@ -45,7 +45,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/zoric
-	name = "Zoric frame"
+	name = "\improper Zoric frame"
 	desc = "A Zoric SMG frame. Workhorse of the Excelsior force."
 	icon_state = "frame_zorik"
 	result = /obj/item/gun/projectile/automatic/zoric

--- a/code/modules/projectiles/guns/projectile/battle_rifle/boltgun.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/boltgun.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/boltgun
-	name = "EX BR .30 \"Kardashev-Mosin\"" //Eclipse Edit - gun names standardized
+	name = "\improper EX BR .30 \"Kardashev-Mosin\"" //Eclipse Edit - gun names standardized
 	desc = "Weapon for hunting, or endless trench warfare. \
 			If you’re on a budget, it’s a darn good rifle for just about everything."
 	icon = 'icons/obj/guns/projectile/boltgun.dmi'
@@ -117,7 +117,7 @@
 	..()
 
 /obj/item/gun/projectile/boltgun/serbian
-	name = "SA BR .30 \"Novakovic\""
+	name = "\improper SA BR .30 \"Novakovic\""
 	desc = "Weapon for hunting, or endless trench warfare. \
 			If you’re on a budget, it’s a darn good rifle for just about everything. \
 			This copy, in fact, is a reverse-engineered poor-quality copy of a more perfect copy of an ancient rifle"
@@ -132,7 +132,7 @@
 
 //Custom item for Yeehawguvnah
 /obj/item/gun/projectile/boltgun/serbian/levergun
-	name = "SA BR .30 \"Greener Grass\""
+	name = "\improper SA BR .30 \"Greener Grass\""
 	desc = "Weapon for \"hunting\". \
 			If you’re on a budget, it’s a darn good rifle for just about everything. \
 			This is a somewhat-modified (and visibly used) rifle, using a lever-operated action. There's an inscription on the side: \"Wish you were here\""
@@ -149,7 +149,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/boltgun = 1, /obj/item/part/gun/grip/wood = 1, /obj/item/part/gun/mechanism/boltgun = 1, /obj/item/part/gun/barrel/lrifle/steel = 1)
 
 /obj/item/gun/projectile/boltgun/fs
-	name = "FS BR .20 \"Tosshin\""
+	name = "\improper FS BR .20 \"Tosshin\""
 	desc = "Weapon for hunting, or endless coastal warfare. \
 			A replica of an ancient bolt action known for its easy maintenance and low price. \
 			This is mounted with a scope, for ranges longer than a maintenance tunnel."
@@ -174,7 +174,7 @@
 	price_tag = 1200
 
 /obj/item/part/gun/frame/tosshin
-	name = "Tosshin frame"
+	name = "\improper Tosshin frame"
 	desc = "A Tosshin bolt-action rifle frame. For hunting or endless coastal warfare."
 	icon_state = "frame_excelrifle"
 	result = /obj/item/gun/projectile/boltgun/fs

--- a/code/modules/projectiles/guns/projectile/battle_rifle/kovacs.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/kovacs.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/kovacs
-	name = "SA BR .20 \"Kovacs\""
+	name = "\improper SA BR .20 \"Kovacs\""
 	desc = "The \"Kovacs\" is a refined battle rifle fit for taking down heavily armoured targets. \
 			This extremely efficient rifle design has gone into disuse over the years but still sees use by mercenaries. \
 			Uses .20 Rifle rounds."
@@ -50,7 +50,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/kovacs
-	name = "Kovacs frame"
+	name = "\improper Kovacs frame"
 	desc = "A Kovacs battle rifle frame. To punch through armor with panache."
 	icon_state = "frame_kovacs"
 	result = /obj/item/gun/projectile/kovacs

--- a/code/modules/projectiles/guns/projectile/battle_rifle/levergun.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/levergun.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/boltgun/levergun
-	name = "FS BR .40 \"Svengali\""
+	name = "\improper FS BR .40 \"Svengali\""
 	desc = "A perfect modernization of an old earth classic hailing popular use with gun ho lawmen and bounty hunters. \
 	When you need someone to have a closed casket funeral!"
 	icon_state = "lever_winchester"
@@ -41,7 +41,7 @@
 	twohanded = FALSE
 
 /obj/item/gun/projectile/boltgun/levergun/shotgun
-	name = "FS BR \"Sogekihei\""
+	name = "\improper FS BR \"Sogekihei\""
 	desc = "A refined weapon for the lawmen who wants to get up close and personal. \
 	Marketed as the number one choice for crack shots on Oberth colonies and large vessels."
 	icon_state = "lever_shotgun"

--- a/code/modules/projectiles/guns/projectile/battle_rifle/type47.dm
+++ b/code/modules/projectiles/guns/projectile/battle_rifle/type47.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/type_47
-	name = "OS CAR .25 CS \"Type XLVII\""
+	name = "\improper OS CAR .25 CS \"Type XLVII\""
 	desc = "A standard-issue weapon used by Onestar peacekeeping forces. Compact and reliable. Uses .25 Caseless rounds."
 	icon = 'icons/obj/guns/projectile/os/type_47.dmi'
 	icon_state = "type_47"

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -42,7 +42,7 @@
 	ammo_states = list(1, 2, 3, 4, 5)
 
 /obj/item/gun/projectile/dartgun
-	name = "ZHP DG \"Artemis\"" //Eclipse Edit - gun names standardized
+	name = "\improper ZHP DG \"Artemis\"" //Eclipse Edit - gun names standardized
 	desc = "Zeng-Hu Pharmaceutical's entry into the arms market, the Z-H P Artemis is a gas-powered dart gun capable of delivering chemical cocktails swiftly across short distances."
 	icon = 'icons/obj/guns/projectile/dartgun.dmi'
 	icon_state = "dartgun-empty"

--- a/code/modules/projectiles/guns/projectile/other/RPG.dm
+++ b/code/modules/projectiles/guns/projectile/other/RPG.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/rpg
-	name = "SA RPG \"RPG-17\"" //Eclipse Edit - gun names standardized
+	name = "\improper SA RPG \"RPG-17\"" //Eclipse Edit - gun names standardized
 	desc = "A modified ancient rocket-propelled grenade launcher, this design is centuries old, but well preserved. \
 			Modification altered gun mechanism to take much more compact, but sligtly less devastating in close quaters rockets and remove backfire. \
 			Their priming and proplusion was altered too for more robust speed, so it has strong recoil."

--- a/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/avasarala.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/avasarala
-	name = "NT HG .40 Magnum \"Avasarala\""
+	name = "\improper NT HG .40 Magnum \"Avasarala\""
 	desc = "An obvious replica of an old Earth \"Desert Eagle\". Robust and straight, this is a gun for a leader, not just an officer."
 
 	icon = 'icons/obj/guns/projectile/avasarala.dmi'
@@ -50,7 +50,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/avasarala
-	name = "Avasarala frame"
+	name = "\improper Avasarala frame"
 	desc = "An Avasarala pistol frame. Something to command respect."
 	icon_state = "frame_deagle"
 	result = /obj/item/gun/projectile/avasarala

--- a/code/modules/projectiles/guns/projectile/pistol/colt.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/colt.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/colt
-	name = "FS HG .35 Auto \"Colt M1911\""
+	name = "\improper FS HG .35 Auto \"Colt M1911\""
 	desc = "A cheap knock-off of a Colt M1911. Uses standard .35 and high capacity magazines."
 	icon = 'icons/obj/guns/projectile/colt.dmi'
 	icon_state = "colt"
@@ -39,7 +39,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/colt
-	name = "Colt 1911 frame"
+	name = "\improper Colt 1911 frame"
 	desc = "A Colt pistol frame. Winner of dozens of world wars, and loser of many more guerilla wars."
 	icon_state = "frame_1911"
 	result = /obj/item/gun/projectile/colt

--- a/code/modules/projectiles/guns/projectile/pistol/giskard.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/giskard.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/giskard
-	name = "FS HG .35 Auto \"Giskard\""
+	name = "\improper FS HG .35 Auto \"Giskard\""
 	desc = "A popular \"Frozen Star\" brand pocket pistol chambered for the ubiquitous .35 auto round. Uses standard capacity magazines."
 	icon = 'icons/obj/guns/projectile/giskard.dmi'
 	icon_state = "giskard"
@@ -46,7 +46,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/giskard
-	name = "Giskard frame"
+	name = "\improper Giskard frame"
 	desc = "A Giskard pistol frame. A ubiquitous pocket deterrent."
 	icon_state = "frame_giskard"
 	result = /obj/item/gun/projectile/giskard

--- a/code/modules/projectiles/guns/projectile/pistol/gyropistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/gyropistol.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/gyropistol
-	name = "NT GP \"Zeus\""
+	name = "\improper NT GP \"Zeus\""
 	desc = "A bulky pistol designed to fire self-propelled rounds."
 	icon = 'icons/obj/guns/projectile/gyropistol.dmi'
 	icon_state = "gyropistol"

--- a/code/modules/projectiles/guns/projectile/pistol/lamia.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/lamia.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/projectile/lamia
-	name = "FS HG .40 Magnum \"Lamia\""
-	desc = "FS HG .40 Magnum \"Lamia\", a heavy pistol of Aegis enforcers. Uses .40 Magnum rounds."
+	name = "\improper FS HG .40 Magnum \"Lamia\""
+	desc = "It's a FS HG .40 Magnum \"Lamia\", a heavy pistol of Aegis enforcers. Uses .40 Magnum rounds."
 	icon = 'icons/obj/guns/projectile/lamia.dmi'
 	icon_state = "lamia"
 	item_state = "lamia"
@@ -35,7 +35,7 @@
 	return
 
 /obj/item/part/gun/frame/lamia
-	name = "Lamia frame"
+	name = "\improper Lamia frame"
 	desc = "A Lamia pistol frame. Summary executions are never the same without it."
 	icon_state = "frame_lamia"
 	result = /obj/item/gun/projectile/lamia

--- a/code/modules/projectiles/guns/projectile/pistol/mandella.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mandella.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/mandella
-	name = "OSDF HG .25 CS \"Mandella\"" //Eclipse Edit - gun names standardized
+	name = "\improper OSDF HG .25 CS \"Mandella\"" //Eclipse Edit - gun names standardized
 	desc = "A rugged, robust operator handgun with inbuilt silencer. Chambered in .25 caseless ammunition, this time-tested handgun is \
 			your absolute choice if you need to take someone down silently, as it's deadly, produces no sound, and leaves no traces. \
 			Built to have enhanced armor penetration abilities. \
@@ -45,7 +45,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/mandella
-	name = "Mandella frame"
+	name = "\improper Mandella frame"
 	desc = "A Mandella pistol frame. Covertness never looked so good."
 	icon_state = "frame_mandella"
 	result = /obj/item/gun/projectile/mandella

--- a/code/modules/projectiles/guns/projectile/pistol/mk58.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/mk58.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/mk58
-	name = "NT HG .35 Auto \"Mk58\""
+	name = "\improper NT HG .35 Auto \"Mk58\""
 	desc = "The NT Mk58 is a cheap, ubiquitous sidearm, that was produced by a NanoTrasen subsidiary. Uses standard .35 and high capacity magazines."
 	icon = 'icons/obj/guns/projectile/mk58.dmi'
 	icon_state = "mk58"
@@ -30,7 +30,7 @@
 
 
 /obj/item/gun/projectile/mk58/wood
-	name = "NT HG .35 Auto \"Mk58-C\""
+	name = "\improper NT HG .35 Auto \"Mk58-C\""
 	desc = "The NT Mk58 is a cheap, ubiquitous sidearm, produced by a NanoTrasen subsidiary. This one has a sweet wooden grip. Uses standard .35 Auto mags."
 	icon_state = "mk58_wood"
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_WOOD = 6)
@@ -38,7 +38,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/mk58 = 1, /obj/item/part/gun/grip/wood = 1, /obj/item/part/gun/mechanism/pistol = 1, /obj/item/part/gun/barrel/pistol = 1)
 
 /obj/item/part/gun/frame/mk58
-	name = "MK58 frame"
+	name = "\improper MK58 frame"
 	desc = "A MK58 pistol frame. The standard issue of the Nanotrasen Corporation."
 	icon_state = "frame_mk58"
 	result = /obj/item/gun/projectile/mk58

--- a/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/olivaw.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/olivaw
-	name = "FS MP .35 Auto \"Olivaw\""
+	name = "\improper FS MP .35 Auto \"Olivaw\""
 	desc = "A popular \"Frozen Star\" machine pistol. This one has a two-round burst-fire mode and is chambered for .35 auto. It can use normal and high capacity magazines."
 	icon = 'icons/obj/guns/projectile/olivawcivil.dmi'
 	icon_state = "olivawcivil"
@@ -32,7 +32,7 @@
 		icon_state = "olivawcivil_empty"
 
 /obj/item/part/gun/frame/olivaw
-	name = "Olivaw frame"
+	name = "\improper Olivaw frame"
 	desc = "An Olivaw pistol frame. Why shoot one bullet when you can shoot two?"
 	icon_state = "frame_olivaw"
 	result = /obj/item/gun/projectile/olivaw

--- a/code/modules/projectiles/guns/projectile/pistol/paco.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/paco.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/paco
-	name = "FS HG .35 Auto \"Paco\""
+	name = "\improper FS HG .35 Auto \"Paco\""
 	desc = "A modern and reliable sidearm for the soldier in the field. Commonly issued as a sidearm to Aegis Operatives. Uses standard .35 and high capacity magazines."
 	icon = 'icons/obj/guns/projectile/paco.dmi'
 	icon_state = "paco"
@@ -50,7 +50,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/paco
-	name = "Paco frame"
+	name = "\improper Paco frame"
 	desc = "A Paco pistol frame. A reliable companion in the field."
 	icon_state = "frame_paco"
 	result = /obj/item/gun/projectile/paco

--- a/code/modules/projectiles/guns/projectile/pistol/selfload.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/selfload.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/selfload
-	name = "S HG .35 Auto \"Clarissa\""
+	name = "\improper S HG .35 Auto \"Clarissa\""
 	desc = "A small, easily concealable, but somewhat underpowered gun. Uses both standard and highcap .35 Auto mags."
 
 	icon = 'icons/obj/guns/projectile/clarissa.dmi'
@@ -51,7 +51,7 @@
 	set_item_state(itemstring)
 
 /obj/item/part/gun/frame/clarissa
-	name = "Clarissa frame"
+	name = "\improper Clarissa frame"
 	desc = "A Clarissa pistol frame. Concealable yet anemic yet fast."
 	icon_state = "frame_clarissa"
 	result = /obj/item/gun/projectile/selfload
@@ -60,7 +60,7 @@
 	barrel = /obj/item/part/gun/barrel/pistol
 
 /obj/item/gun/projectile/selfload/makarov
-	name = "EX .35 Auto \"Makarov\"" //Eclipse Edit - gun names standardized
+	name = "\improper EX .35 Auto \"Makarov\"" //Eclipse Edit - gun names standardized
 	desc = "An old design pistol popular among space communists. Small and easily concealable. Uses .35 Auto rounds." //Eclipse Edit - grammar
 	icon = 'icons/obj/guns/projectile/makarov.dmi'
 	icon_state = "makarov"
@@ -74,7 +74,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/makarov = 1, /obj/item/part/gun/grip/excel = 1, /obj/item/part/gun/mechanism/pistol = 1, /obj/item/part/gun/barrel/pistol = 1)
 
 /obj/item/part/gun/frame/makarov
-	name = "Makarov frame"
+	name = "\improper Makarov frame"
 	desc = "A Makarov pistol frame. Technology may have stagnated, but effectiveness hasn't."
 	icon_state = "frame_makarov"
 	result = /obj/item/gun/projectile/selfload/makarov
@@ -83,6 +83,6 @@
 	barrel = /obj/item/part/gun/barrel/pistol
 
 /obj/item/gun/projectile/selfload/moebius
-	name = "Lazarus HG .35 Auto \"Anne\"" // ML stands for Moebius Laboratories
+	name = "\improper Lazarus HG .35 Auto \"Anne\"" // ML stands for Moebius Laboratories
 	desc = "Self-loading pistol of Syndicate design reverse-engineered. Uses both standard and highcap .35 Auto mags."
 	icon = 'icons/obj/guns/projectile/clarissa_white.dmi'

--- a/code/modules/projectiles/guns/projectile/pistol/type42.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/type42.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/type_42
-	name = "OS HG .25 CS \"Type XLII\""
+	name = "\improper OS HG .25 CS \"Type XLII\""
 	desc = "An old Onestar pistol, designed with esoteric mechanisms. Uses .25 Caseless rounds."
 	icon = 'icons/obj/guns/projectile/os/type_42.dmi'
 	icon_state = "type_42"

--- a/code/modules/projectiles/guns/projectile/pistol/type69.dm
+++ b/code/modules/projectiles/guns/projectile/pistol/type69.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/type_69
-    name = "OS MP .40 \"Type LXIX\""
+    name = "\improper OS MP .40 \"Type LXIX\""
     desc = "A Onestar machine pistol. While unwieldy, its users can't deny that it is brutally effective. Uses .40 pistol magazines." //Eclipse Edit - grammar
     icon = 'icons/obj/guns/projectile/os/type_69.dmi'
     icon_state = "type_69"

--- a/code/modules/projectiles/guns/projectile/revolver/artwork_revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/artwork_revolver.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/revolver/artwork_revolver
-	name = "Weird Revolver"
+	name = "weird revolver"
 	desc = "This is an artistically-made revolver."
 	icon = 'icons/obj/guns/projectile/artwork_revolver.dmi'
 	icon_state = "artwork_revolver_1"

--- a/code/modules/projectiles/guns/projectile/revolver/capgun.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/capgun.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/revolver/capgun
-	name = "FS REV .357 \"Miller\"" //for that epic clown robbery meme
+	name = "\improper FS REV .357 \"Miller\"" //for that epic clown robbery meme
 	desc = "Looks almost like the real thing! Ages 8 and up."
 	icon_state = "revolver"
 	item_state = "revolver"

--- a/code/modules/projectiles/guns/projectile/revolver/consul.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/consul.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/revolver/consul
-	name = "FS REV .40 Magnum \"Consul\""
+	name = "\improper FS REV .40 Magnum \"Consul\""
 	desc = "When you badly need this case to be closed. Uses .40 Magnum rounds."
 	icon = 'icons/obj/guns/projectile/inspector.dmi'
 	icon_state = "inspector"
@@ -18,7 +18,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/consul = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/revolver = 1, /obj/item/part/gun/barrel/magnum = 1)
 
 /obj/item/part/gun/frame/consul
-	name = "Consul frame"
+	name = "\improper Consul frame"
 	desc = "A Consul revolver frame. The standard detective's choice."
 	icon_state = "frame_inspector"
 	result = /obj/item/gun/projectile/revolver/consul

--- a/code/modules/projectiles/guns/projectile/revolver/deckard.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/deckard.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/revolver/deckard
-	name = "FS REV .40 Magnum \"Deckard\""
+	name = "\improper FS REV .40 Magnum \"Deckard\""
 	desc = "A rare, custom-built revolver. Use when there is no time for Voight-Kampff tests. Uses .40 Magnum rounds." //Eclipse Edit - grammar
 	icon = 'icons/obj/guns/projectile/deckard.dmi'
 	icon_state = "deckard"
@@ -16,7 +16,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/deckard = 1, /obj/item/part/gun/grip/wood = 1, /obj/item/part/gun/mechanism/revolver = 1, /obj/item/part/gun/barrel/magnum = 1)
 
 /obj/item/part/gun/frame/deckard
-	name = "Deckard frame"
+	name = "\improper Deckard frame"
 	desc = "A Deckard revolver frame. The secret policeman's choice."
 	icon_state = "frame_thatgun"
 	result = /obj/item/gun/projectile/revolver/deckard

--- a/code/modules/projectiles/guns/projectile/revolver/havelock.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/havelock.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/revolver/havelock
-	name = "FS REV .35 Auto \"Havelock\""
+	name = "\improper FS REV .35 Auto \"Havelock\""
 	desc = "A cheap Frozen Star knock-off of a Smith & Wesson Model 10. Uses .35 Special rounds."
 	icon = 'icons/obj/guns/projectile/havelock.dmi'
 	icon_state = "havelock"
@@ -21,7 +21,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/havelock = 1, /obj/item/part/gun/grip/wood = 1, /obj/item/part/gun/mechanism/revolver = 1, /obj/item/part/gun/barrel/pistol = 1)
 
 /obj/item/part/gun/frame/havelock
-	name = "Havelock frame"
+	name = "\improper Havelock frame"
 	desc = "A Havelock revolver frame. Personal defense in a small package."
 	icon_state = "frame_havelock"
 	result = /obj/item/gun/projectile/revolver/havelock

--- a/code/modules/projectiles/guns/projectile/revolver/mateba.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/mateba.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/revolver/mateba
-	name = "FS REV .40 Magnum \"Mateba\""
+	name = "\improper FS REV .40 Magnum \"Mateba\""
 	desc = "Very old, reliable hand-cannon with a robust design. This is a gun for a real officer, not just a self-proclaimed \"leader\". Revolver of choice when you want to put someone down. Permanently. Uses .40 Magnum ammo."
 	icon = 'icons/obj/guns/projectile/mateba.dmi'
 	icon_state = "mateba"
@@ -14,7 +14,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/mateba = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/revolver = 1, /obj/item/part/gun/barrel/magnum = 1)
 
 /obj/item/part/gun/frame/mateba
-	name = "Mateba frame"
+	name = "\improper Mateba frame"
 	desc = "A Mateba revolver frame. The officer's choice."
 	icon_state = "frame_mateba"
 	result = /obj/item/gun/projectile/revolver/mateba

--- a/code/modules/projectiles/guns/projectile/revolver/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/revolver.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/revolver
-	name = "FS REV .40 Magnum \"Miller\""
+	name = "\improper FS REV .40 Magnum \"Miller\""
 	desc = "The \"Frozen Star\" \"Miller\" is a revolver of choice when you absolutely, positively need to make a hole in someone. Uses .40 Magnum ammo."
 	icon = 'icons/obj/guns/projectile/revolver.dmi'
 	icon_state = "revolver"
@@ -86,7 +86,7 @@
 	gun_tags |= GUN_REVOLVER
 
 /obj/item/part/gun/frame/miller
-	name = "Miller frame"
+	name = "\improper Miller frame"
 	desc = "A Miller revolver frame. I hope you're feeling lucky, punk."
 	icon_state = "frame_revolver"
 	result = /obj/item/gun/projectile/revolver/mateba

--- a/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/revolver/sky_driver
-	name = "S REV .35 Auto \"Sky Driver\""
+	name = "\improper S REV .35 Auto \"Sky Driver\""
 	desc = "A prototype revolver, captured as a trophy from a raided Syndicate research base. Uses .35 Special rounds."
 	icon = 'icons/obj/guns/projectile/sky_driver.dmi'
 	icon_state = "sky_driver"
@@ -39,7 +39,7 @@
 	..()
 
 /obj/item/part/gun/frame/sky_driver
-	name = "Sky Driver frame"
+	name = "\improper Sky Driver frame"
 	desc = "A Sky Driver revolver frame. A device that can put holes in ships, let alone a person."
 	icon_state = "frame_skydriver"
 	result = /obj/item/gun/projectile/revolver/sky_driver

--- a/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/shotgun/bojevic
-	name = "SA SG \"Bojevic\""
+	name = "\improper SA SG \"Bojevic\""
 	desc = "Semi-auto, half polymer, all serbian. \
 			It's magazine-fed shotgun designed for close quarters combat, nicknamed 'Striker' by boarding parties. \
 			Robust and reliable design allows you to swap magazines on go and dump as many shells at your foes as you want... \
@@ -53,7 +53,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/bojevic
-	name = "Bojevic frame"
+	name = "\improper Bojevic frame"
 	desc = "A Bojevic shotgun frame. Specially designed to sweep streets and spaceship halls."
 	icon_state = "frame_bojevic"
 	result = /obj/item/gun/projectile/shotgun/bojevic

--- a/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bojevic.dm
@@ -30,6 +30,8 @@
 		SEMI_AUTO_NODELAY
 		)
 	gun_parts = list(/obj/item/part/gun/frame/bojevic = 1, /obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/shotgun = 1, /obj/item/part/gun/barrel/shotgun = 1)
+	
+	simplemob_bonus_damage_multiplier = -0.1 //Eclipse edit: Balancing.
 
 /obj/item/gun/projectile/shotgun/bojevic/update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/shotgun/bull.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/bull.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/shotgun/bull
-	name = "FS SG \"Bull\""
+	name = "\improper FS SG \"Bull\""
 	desc = "A \"Frozen Star\" double-barreled pump-action shotgun. Marvel of engineering, this gun is often used by Aegis tactical units. \
 			Due to shorter than usual barrels, damage are somewhat lower and recoil kicks slightly harder, but possibility to fire two barrels at once overshadows all bad design flaws."
 	icon = 'icons/obj/guns/projectile/bull.dmi'
@@ -106,7 +106,7 @@
 	update_charge()
 
 /obj/item/part/gun/frame/bull
-	name = "Bull frame"
+	name = "\improper Bull frame"
 	desc = "A Bull shotgun frame. Double-barrel and pump action, through a miracle of engineering."
 	icon_state = "frame_bull"
 	result = /obj/item/gun/projectile/shotgun/bull

--- a/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/gladstone.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/shotgun/pump/gladstone
-	name = "FS SG \"Gladstone\""
+	name = "\improper FS SG \"Gladstone\""
 	desc = "It is a next-generation Frozen Star shotgun intended as a cost-effective competitor to the aging NT \"Regulator 1000\". It has a semi-rifled lightweight full-length barrel which gives it exceptional projectile velocity and armor piercing capabilites with slugs, with a high-capacity magazine tube below it. Can hold up to 9 shells in a tube magazine."
 	icon = 'icons/obj/guns/projectile/gladstone.dmi'
 	icon_state = "gladstone"
@@ -20,7 +20,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/gladstone = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/shotgun = 1, /obj/item/part/gun/barrel/shotgun = 1)
 
 /obj/item/part/gun/frame/gladstone
-	name = "Gladstone frame"
+	name = "\improper Gladstone frame"
 	desc = "A Gladstone shotgun frame. Where capacity and force combine."
 	icon_state = "frame_gladstone"
 	result = /obj/item/gun/projectile/shotgun/pump/gladstone

--- a/code/modules/projectiles/guns/projectile/shotgun/pump.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/pump.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/shotgun/pump
-	name = "FS SG \"Kammerer\""
+	name = "\improper FS SG \"Kammerer\""
 	desc = "When an old Remington design meets modern materials, this is the result. A favourite weapon of militia forces throughout many worlds."
 	icon = 'icons/obj/guns/projectile/shotgun.dmi'
 	icon_state = "shotgun"
@@ -51,7 +51,7 @@
 	update_icon()
 
 /obj/item/part/gun/frame/kammerer
-	name = "Kammerer frame"
+	name = "\improper Kammerer frame"
 	desc = "A Kammerer shotgun frame. A militiaman's favorite."
 	icon_state = "frame_shotgun"
 	result = /obj/item/gun/projectile/shotgun/pump

--- a/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun/regulator.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/shotgun/pump/regulator
-	name = "NT SG \"Regulator 1000\""
+	name = "\improper NT SG \"Regulator 1000\""
 	desc = "Designed for close quarters combat, the Regulator is widely regarded as a weapon of choice for repelling boarders. \
 			Some may say that it's too old, but it actually proved itself useful. Can hold up to 7 shells in tube magazine."
 	icon = 'icons/obj/guns/projectile/regulator.dmi'
@@ -18,7 +18,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/regulator = 1, /obj/item/part/gun/grip/black = 1, /obj/item/part/gun/mechanism/shotgun = 1, /obj/item/part/gun/barrel/shotgun = 1)
 
 /obj/item/part/gun/frame/regulator
-	name = "Regulator frame"
+	name = "\improper Regulator frame"
 	desc = "A Regulator shotgun frame. The gold standard for boarder repelling."
 	icon_state = "frame_regulator"
 	result = /obj/item/gun/projectile/shotgun/pump/regulator

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/heavysniper
-	name = "SA AMR .60 \"Hristov\""
+	name = "\improper SA AMR .60 \"Hristov\""
 	desc = "A portable anti-armour rifle, fitted with a night-vision scope, it was originally designed for use against armored exosuits. It is capable of punching through windows and non-reinforced walls with ease, but suffers from overpenetration at close range. Fires armor piercing .60 shells. Can be upgraded using thermal glasses."
 	icon = 'icons/obj/guns/projectile/heavysniper.dmi'
 	icon_state = "heavysniper"
@@ -36,7 +36,7 @@
 	gun_parts = list(/obj/item/part/gun/frame/heavysniper = 1, /obj/item/part/gun/grip/serb = 1, /obj/item/part/gun/mechanism/boltgun = 1, /obj/item/part/gun/barrel/antim = 1)
 
 /obj/item/part/gun/frame/heavysniper
-	name = "Hristov frame"
+	name = "\improper Hristov frame"
 	desc = "A Hristov AMR frame. For removing chunks of man and machine alike."
 	icon_state = "frame_antimaterial"
 	result = /obj/item/gun/projectile/heavysniper

--- a/zzz_modular_eclipse/code/modules/projectiles/guns/projectile/automatic/olympus.dm
+++ b/zzz_modular_eclipse/code/modules/projectiles/guns/projectile/automatic/olympus.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/automatic/olympus
-	name = "FS AR .20 \"Olympus\""
+	name = "\improper FS AR .20 \"Olympus\""
 	desc = "The Olympus was Initially set up as an alternative for wealthy planetary defense forces seeking a hard-hitting yet controllable primary weapon for their forces. It proved to be an initial commercial failure due to its egregious price tag, but found a second life within wealthy bodyguard units seeking a compact yet hard-hitting rifle."
 	icon = 'zzz_modular_eclipse/icons/obj/guns/projectile/olympus.dmi'
 	icon_state = "olympus"

--- a/zzz_modular_eclipse/code/modules/projectiles/guns/projectile/automatic/olympus.dm
+++ b/zzz_modular_eclipse/code/modules/projectiles/guns/projectile/automatic/olympus.dm
@@ -31,6 +31,8 @@
 		BURST_3_ROUND
 		)
 
+	simplemob_bonus_damage_multiplier = 0.1
+
 	spawn_tags = SPAWN_TAG_FS_PROJECTILE
 
 	gun_tags = list(GUN_SILENCABLE)

--- a/zzz_modular_eclipse/maverick_laser_rifle/code/maverick.dm
+++ b/zzz_modular_eclipse/maverick_laser_rifle/code/maverick.dm
@@ -2,7 +2,7 @@
 // R.A. Spitzer 2022-07-10
 
 /obj/item/gun/energy/lever_action
-	name = "CA ELAR S \"Maverick\"" 
+	name = "\improper CA ELAR S \"Maverick\"" 
 	desc = "A revision of Chiropteran Arms' popular lever-action varmint-hunting rifle, this rifle design was produced in smaller numbers for colonists who needed the versatility of a laser weapon with the power of a ballistic weapon."
 	
 	//Icon and sounds. //TODO TODO TODO - CHANGE ALL THIS!

--- a/zzz_modular_eclipse/maverick_laser_rifle/code/maverick.dm
+++ b/zzz_modular_eclipse/maverick_laser_rifle/code/maverick.dm
@@ -22,8 +22,8 @@
 	force = WEAPON_FORCE_NORMAL
 	projectile_type = /obj/item/projectile/beam/midlaser
 	init_firemodes = list(WEAPON_NORMAL)
-	damage_multiplier = 1 //Base of 30 damage at 250 charge.
-	simplemob_bonus_damage_multiplier = 0.3 //Mobs take 30% extra damage.
+	damage_multiplier = 1.5 //Base of 45 damage at 250 charge.
+	simplemob_bonus_damage_multiplier = 0.5 //Mobs take 30% extra damage.
 	
 	//Reference values.
 	var/charge_maximum = 400 //Damage multiplier caps at this amount.

--- a/zzz_modular_eclipse/maverick_laser_rifle/code/maverick_diskette.dm
+++ b/zzz_modular_eclipse/maverick_laser_rifle/code/maverick_diskette.dm
@@ -1,0 +1,19 @@
+// Chiropteran Arms "Maverick" series rifle - design diskette and autolathe defines.
+// R.A. Spitzer 2022-09-13
+
+//Design diskette.
+/obj/item/computer_hardware/hard_drive/portable/design/maverick
+	disk_name = "Chiropteran Arms - Maverick Rifle E"
+	icon_state = "frozenstar"
+	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED_COMMON
+	license = 12
+	designs = list(
+		/datum/design/autolathe/gun/maverick = 3,
+		/datum/design/autolathe/cell/small/high,
+	)
+
+//Autolathe datum
+/datum/design/autolathe/gun/maverick
+	name = "CA ELAR \"Maverick\""
+	build_path = /obj/item/gun/energy/lever_action
+	materials = list(MATERIAL_STEEL = 15, MATERIAL_PLASTIC = 3, MATERIAL_SILVER = 4)

--- a/zzz_modular_eclipse/maverick_laser_rifle/code/maverick_procs.dm
+++ b/zzz_modular_eclipse/maverick_laser_rifle/code/maverick_procs.dm
@@ -42,7 +42,7 @@
 
 	if(cell)//We have a shell in the chamber
 		cell.forceMove(newloc) //Eject casing
-		cell.SpinAnimation(rand(6,9), 1)
+		cell.SpinAnimation(rand(7,9), 1)
 		cell = null
 
 	if(magazine.len)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Blob is now a bit tougher. Implemented simplemob bonus damage on a few firearms. Re-balanced the Maverick a bit. Made all firearm names improper. Adds a Maverick diskette, so players can build the thing themselves. Converted the Type 17 file to use leading tabs instead of leading spaces.

## Why It's Good For The Game
* The blob, for a long time, has been the regular Lowpop-Manageable Disaster event. However, players being able to one-man bum-rush the blob is an issue, which this hopes to fix. The health of regular Blob tiles is doubled (shield tiles remain untouched), their spread rate has been marginally increased, and they now cool their areas down much faster.
* Simplemob bonus damage being implemented on a few more firearms helps to shake up the meta a little bit, and also gives another chance for guns that players normally wouldn't think twice about. 
* The Maverick, with a basic 100S cell, currently deals the third-lowest per-shot damage of any firearm in the game. 
* Most of the guns in the game have had \improper put in front of their name. This turns "This is Wintermute" into "This is a Wintermute". Also, some assorted spelling-and-grammar fixes within the descriptions, mods, et cetera.
* The diskette allows people to build the Maverick for themselves, without having to shell out lodsofemone to buy one.
* I really, *really* despise inconsistent indentation. Byond does, as well.

## Test status
Compiler-tested, compiles OK.

## Changelog
:cl: EvilJackCarver
spellcheck: All firearm names now have the \improper flag, turning their examine text from "This is Wintermute" to "This is a Wintermute".
spellcheck: Minor spelling and grammar tweaks to firearms and firearm mods.
add: Maverick now has a diskette.
balance: Rebalanced some firearms with low damage.
balance: Blob is now a bit tougher to beat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
