### PR TITLE
Revert "Stat limiter"

### DIFF
--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -3,7 +3,6 @@
 	var/list/stat_list = list()
 	var/list/datum/perk/perks = list()
 	var/list/obj/effect/perk_stats = list() // Holds effects representing perks, to display them in stat()
-	var/statMax = 150
 
 /datum/stat_holder/New(mob/living/L)
 	holder = L
@@ -48,11 +47,7 @@
 
 /datum/stat_holder/proc/changeStat(statName, Value)
 	var/datum/stat/S = stat_list[statName]
-	if(S + Value <= statMax)
-		S.changeValue(Value)
-	else
-		S.setValue(statMax) //Eclipse Edit: Changes stats to not exceed a certain value. Editable at top of file.
-
+	S.changeValue(Value)
 	SEND_SIGNAL(holder, COMSIG_STAT, S.name, S.getValue(), S.getValue(TRUE))
 
 /datum/stat_holder/proc/setStat(statName, Value)

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -84,6 +84,7 @@
 		if(stage == 1 && prob(20))
 			src.cure(mob)
 		return
+
 	//Virus food speeds up disease progress
 	if(mob.reagents.has_reagent("virusfood"))
 		mob.reagents.remove_reagent("virusfood",0.1)


### PR DESCRIPTION
Reverts Eclipse-Station/NEV-Northern-Light#1685

The PR made all players spawn with no stats.