### PR TITLE
Admins (and players, if no admins are on) are now warned if the mobs subsystem has too much to handle.

### DIFF
--- a/code/controllers/subsystems/processing/mobs.dm
+++ b/code/controllers/subsystems/processing/mobs.dm
@@ -9,6 +9,10 @@ PROCESSING_SUBSYSTEM_DEF(mobs)
 
 	var/list/mob_list
 	var/list/mob_living_by_zlevel[][]
+	
+	//ECLIPSE ADDED VARS
+	var/alarm = FALSE
+	var/alarm_time
 
 /datum/controller/subsystem/processing/mobs/PreInit()
 	mob_list = processing // Simply setups a more recognizable var name than "processing"
@@ -21,3 +25,26 @@ PROCESSING_SUBSYSTEM_DEF(mobs)
 	while(mob_living_by_zlevel.len < world.maxz)
 		mob_living_by_zlevel.len++
 		mob_living_by_zlevel[mob_living_by_zlevel.len] = list()
+
+//ECLIPSE ADDED SPAGHETTI BEYOND THIS POINT
+//ABANDON ALL HOPE YE WHO ENTER HERE.
+/datum/controller/subsystem/processing/mobs/fire(resumed = 0)
+	..()		//Run everything else first.
+	
+	if(!alarm && mob_list.len > 2000)		//If we ever get this high, something has gone seriously wrong.
+		alarm = TRUE
+	if(alarm)		//If we're in alarm, notify everyone.
+		if(mob_list.len > 2000)
+			if(times_fired > alarm_time)
+				alarm_time = times_fired + 60		//Once every 2 seconds, so warn us every 2 minutes.
+				message_admins("MOB/SEVERE: !! DANGER !! Total number of mobs exceeds reasonable limits. Performance issues are imminent if left unchecked. Check the subsystem variables for any mobs that are spawning uncontrollably.")
+				log_admin("MOB/SEVERE: !! DANGER !! Total number of mobs exceeds reasonable limits. Performance issues are imminent if left unchecked. Check the subsystem variables for any mobs that are spawning uncontrollably.")
+				var/admins_online
+				for(var/client/C in admins)
+					if(R_ADMIN & C.holder.rights)		//Admins can fix this. Mods cannot.
+						admins_online = TRUE
+						break
+				if(!admins_online)		//Nobody's on that can fix this. Yell at the players to call an admin.
+					to_world(SPAN_DANGER("SUBSYSTEM WARNING: An issue has been detected with the Mobs subsystem and no administrators are online to correct it. Please notify administrators of this in Discord. Include the following debugging information: \" SUBST_MOBS/0x7D0 EXCESSIVE MOB COUNT\"."))
+		else
+			alarm = FALSE


### PR DESCRIPTION
Basic warnings, so we can catch it before it becomes a huge problem.

## Changelog
:cl:
add: Adds a warning if the number of mobs gets too insane.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
