### PR TITLE
Changelog:

### DIFF
--- a/code/modules/core_implant/cruciform/modules.dm
+++ b/code/modules/core_implant/cruciform/modules.dm
@@ -180,7 +180,7 @@
 
 /datum/core_module/rituals/cruciform/priest/acolyte
 	ritual_types = list(/datum/ritual/cruciform/priest/acolyte,
-	/datum/ritual/targeted/cruciform/priest/acolyte)
+	/datum/ritual/targeted/cruciform/priest/acolyte,/datum/ritual/cruciform/priest/reincarnation)
 
 
 /datum/core_module/rituals/cruciform/inquisitor

--- a/code/modules/core_implant/cruciform/modules.dm
+++ b/code/modules/core_implant/cruciform/modules.dm
@@ -180,7 +180,7 @@
 
 /datum/core_module/rituals/cruciform/priest/acolyte
 	ritual_types = list(/datum/ritual/cruciform/priest/acolyte,
-	/datum/ritual/targeted/cruciform/priest/acolyte,/datum/ritual/cruciform/priest/reincarnation)
+	/datum/ritual/targeted/cruciform/priest/acolyte,/datum/ritual/cruciform/priest/reincarnation) //Eclipse Edit
 
 
 /datum/core_module/rituals/cruciform/inquisitor


### PR DESCRIPTION
- Added the resurrection litany to the acolyte

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the resurrection litany to the acolytes so they may attach the cruciforms on newly-resurrected bodies. Fixes #1693 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your Pull Request fixes an issue, please write "Fixes #1234" or "Closes #5678" so the issue automatically closes when the PR is merged. For more information, see Contributing.MD for further information. --->

## Why It's Good For The Game
It does not make sense that Acolytes can induct new people, but not resurrect existing ones. This way, if a priest is not on but a member of the church is, you may be respawned.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Resurrection Litany to Acolytes 

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
