### PR TITLE
Temporarily removes Mimics from the server

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -598,7 +598,6 @@
 #include "code\game\gamemodes\events\spacevine.dm"
 #include "code\game\gamemodes\events\spider_infestation.dm"
 #include "code\game\gamemodes\events\supply_pod.dm"
-#include "code\game\gamemodes\events\vermin.dm"
 #include "code\game\gamemodes\events\viral_infection.dm"
 #include "code\game\gamemodes\events\wallrot.dm"
 #include "code\game\gamemodes\events\weather.dm"


### PR DESCRIPTION
- Temporarily removes the vermin.dm file pending changes

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Temporarily removes the vermin.dm file from the compiled server to not allow it be picked as a story event
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your Pull Request fixes an issue, please write "Fixes #1234" or "Closes #5678" so the issue automatically closes when the PR is merged. For more information, see Contributing.MD for further information. --->

## Why It's Good For The Game
Mimics have caused more than a few rounds to be ended prematurely, not via killing the crew but by causing: Incredible amounts of Ship damage, Venting out wide swaths of the ship in a relatively short amount of time, or just causing a massive slowdown on the server itself until they are dealt with. They reproduce too quickly in the amount of time before the crew can be notified, and they can easily get away from a spawn location when there aren't enough crew aboard to have access to where the mimics are. It may be worthwhile to take them down pending a server-player limiter and some further tweaks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Temporarily removed mimics
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
