### PR TITLE
Update simulated.dm

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -13,7 +13,7 @@
 	nitrogen = MOLES_N2STANDARD
 	var/to_be_destroyed = 0 //Used for fire, if a melting temperature was reached, it will be destroyed
 	var/max_fire_temperature_sustained = 0 //The max temperature of the fire which it was subjected to
-
+	var/dirt //Eclipse Edit - adds a war for making floors dirty
 
 
 /turf/simulated/New()
@@ -21,7 +21,7 @@
 	if(istype(loc, /area/eris/neotheology))
 		holy = 1
 	levelupdate()
-
+	dirt = rand(0, 40) // Eclipse Edit - Has the var assign a random number, so floors will get dirty semi-randomly
 
 
 /turf/simulated/Entered(atom/A, atom/OL)
@@ -33,6 +33,11 @@
 		var/mob/living/M = A
 		if(M.lying)
 			return ..()
+		dirt++ //Eclipse Edit - Floors get dirty as they're walked on
+		if (dirt > 40)
+			dirt = 0
+			if (!locate(/obj/effect/decal/cleanable/dirt, src))
+				new /obj/effect/decal/cleanable/dirt(src)
 
 		// Ugly hack :( Should never have multiple plants in the same tile.
 		var/obj/effect/plant/plant = locate() in contents

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -33,11 +33,11 @@
 		var/mob/living/M = A
 		if(M.lying)
 			return ..()
-		dirt++ //Eclipse Edit - Floors get dirty as they're walked on
+		dirt++ //Begin Eclipse Edit - Floors get dirty as they're walked on
 		if (dirt > 40)
 			dirt = 0
 			if (!locate(/obj/effect/decal/cleanable/dirt, src))
-				new /obj/effect/decal/cleanable/dirt(src)
+				new /obj/effect/decal/cleanable/dirt(src) 		//End of Eclipse Edit
 
 		// Ugly hack :( Should never have multiple plants in the same tile.
 		var/obj/effect/plant/plant = locate() in contents

--- a/code/game/turfs/simulated/cleaning.dm
+++ b/code/game/turfs/simulated/cleaning.dm
@@ -30,6 +30,7 @@
 /turf/simulated/clean_blood()
 	for(var/obj/effect/decal/cleanable/blood/B in contents)
 		B.clean_blood()
+	dirt = 0 //Eclipse Edit - anything that can clean blood can also clean the "dirt" off the floor
 	..()
 
 //expects an atom containing the reagents used to clean the turf


### PR DESCRIPTION
## About The Pull Request
- Makes dirt overlay appear over tile if people walk over it often. Gives custodians more to do (and legit excuse for antag custodians to go everywhere)

## Why It's Good For The Game
the Northern Light is meant to be a dirty, crusty, ancient ship that is barely held together by the willpower of its crew. This change helps reflect that by showing the dirt of passing crew. It will give people more reasons to call the Custodian to their department, and keep the ship looking "lived in."
## Changelog
:cl:
add: Floors will now get dirty as they are walked over more.
/:cl:
