### PR TITLE
Update utility_closets.dm

### DIFF
--- a/zzz_modular_eclipse/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/zzz_modular_eclipse/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -9,7 +9,6 @@
 
 
 /obj/structure/closet/mopcloset/populate_contents()
-	new /obj/structure/mopbucket(src)
 	new /obj/item/reagent_containers/glass/bucket(src)
 	new /obj/item/mop(src)
 	new /obj/item/soap/nanotrasen(src)

--- a/zzz_modular_eclipse/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/zzz_modular_eclipse/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -8,7 +8,7 @@
 	spawn_tags = SPAWN_TAG_CLOSET
 
 
-/obj/structure/closet/bombcloset/populate_contents()
+/obj/structure/closet/mopcloset/populate_contents()
 	new /obj/structure/mopbucket(src)
 	new /obj/item/reagent_containers/glass/bucket(src)
 	new /obj/item/mop(src)


### PR DESCRIPTION
## About The Pull Request

changes 1 line so that the populate contents proc actually populates the new mopclosets, instead of overriding the EOD closets

## Why It's Good For The Game

When I added the mop closets, I removed all of hte loose mops and buckets from around the ship. without this change, the Custodian is literally the only person with a mop on the ship right now. 
## Changelog
:cl:
fix: fixed mop closets not populating contents.
/:cl:

