### PR TITLE
Fixes blood and other smaller objects stunlocking tech

### DIFF
--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -183,7 +183,9 @@ see multiz/movement.dm for some info.
 		// Handle people getting hurt, it's funny!
 		mover.fall_impact(src, below)
 
-
+		//NEV edit
+		if(!isobj(mover))
+			return //Things that are not objs dont stun folks
 
 		for(var/mob/living/M in below)
 			var/fall_damage = mover.get_fall_damage()
@@ -195,8 +197,9 @@ see multiz/movement.dm for some info.
 
 			if(M == mover)
 				continue
-			if(M.getarmor(BP_HEAD, ARMOR_MELEE) < fall_damage || ismob(mover))
-				M.Weaken(10)
+			//Armor + 5 so we dont get stunlocked by not waring a hat and someone throws like 1 bullet case at a time - NEV edit of course
+			if(M.getarmor(BP_HEAD, ARMOR_MELEE) + 5 < fall_damage || ismob(mover))
+				M.Weaken(clamp(1, 10, fall_damage - 5 -M.getarmor(BP_HEAD, ARMOR_MELEE)))
 			if(fall_damage >= FALL_GIB_DAMAGE)
 				M.gib()
 			else


### PR DESCRIPTION

## About The Pull Request

Dripping blood, throwing single bullet cases and other smaller objects down onto someone to stun them is now patched.
The maxium stun now is 10 weaken as before but based on fall damage, armor and other affects can be reduced to next to none

## Why It's Good For The Game

Stunlocking people by bleeding is not fun

## Testing

By dripping blood onto someone below a catwalk, throwing single bulletcases, then a gold bar then finnally a pistol to see the different stun timer affects working

## Changelog
:cl:
tweak: Maths and protection against falling items is greatly tweaked to prevent stunlocking
balance: Only objects now stun people and monsters when falling onto them
f
/:cl:

