### PR TITLE
Fixes oddies not being detected in clothing

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -112,6 +112,20 @@
 	. = ..()
 	gunshot_residue = null
 
+//NEV edit, allows for items hiden inside clothing to be seeable, shuch as shoe knifes and vest items
+/obj/item/clothing/proc/return_inv()
+	var/list/L = list()
+
+	L += src.contents
+
+	for(var/obj/item/storage/S in src)
+		L += S.return_inv()
+	for(var/obj/item/gift/G in src)
+		L += G.gift
+		if (istype(G.gift, /obj/item/storage))
+			L += G.gift:return_inv()
+	return L
+
 //Delayed equipping
 /obj/item/clothing/pre_equip(mob/user, slot)
 	..(user, slot)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -112,7 +112,7 @@
 	. = ..()
 	gunshot_residue = null
 
-//NEV edit, allows for items hiden inside clothing to be seeable, shuch as shoe knifes and vest items
+//eclipse edit, allows for items hiden inside clothing to be seeable, shuch as shoe knifes and vest items
 /obj/item/clothing/proc/return_inv()
 	var/list/L = list()
 
@@ -124,7 +124,10 @@
 		L += G.gift
 		if (istype(G.gift, /obj/item/storage))
 			L += G.gift:return_inv()
+	for(var/obj/item/rig_module/RM in src)
+		L += RM.return_inv()
 	return L
+//End of eclipse edit
 
 //Delayed equipping
 /obj/item/clothing/pre_equip(mob/user, slot)

--- a/code/modules/clothing/spacesuits/rig/modules/modules.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/modules.dm
@@ -59,7 +59,7 @@
 
 	var/list/stat_rig_module/stat_modules = new()
 
-	
+
 
 /obj/item/rig_module/get_cell()
 	holder = get_rig()
@@ -374,3 +374,22 @@
 		name = "[charge.display_name] ([charge.charges]C) - Change"
 		return 1
 	return 0
+
+//eclipse edit, allows for items hiden inside rig modules to be seeable, shuch as in storage units
+/obj/item/rig_module/proc/return_inv()
+	var/list/L = list()
+
+	L += src.contents
+
+	for(var/obj/item/storage/S in src)
+		L += S.return_inv()
+	for(var/obj/item/gift/G in src)
+		L += G.gift
+		if (istype(G.gift, /obj/item/storage))
+			L += G.gift:return_inv()
+	//If somehow we have nested storage
+	for(var/obj/item/rig_module/RM in src)
+		L += RM.return_inv()
+
+	return L
+//End of Eclipse edit

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -1058,3 +1058,21 @@
 #undef ONLY_DEPLOY
 #undef ONLY_RETRACT
 #undef SEAL_DELAY
+
+//eclipse edit, allows for items hiden inside rigs to be seeable, shuch as in storage units
+/obj/item/rig/proc/return_inv()
+	var/list/L = list()
+
+	L += src.contents
+
+	for(var/obj/item/storage/S in src)
+		L += S.return_inv()
+	for(var/obj/item/gift/G in src)
+		L += G.gift
+		if (istype(G.gift, /obj/item/storage))
+			L += G.gift:return_inv()
+	for(var/obj/item/rig_module/RM in src)
+		L += RM.return_inv()
+
+	return L
+//End of Eclipse edit

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -353,6 +353,10 @@ default behaviour is:
 			L += D.wrapped
 			if(istype(D.wrapped, /obj/item/storage)) //this should never happen
 				L += get_contents(D.wrapped)
+
+		for(var/obj/item/clothing/C in Storage.return_inv())//Check for pockets and shoe knifes
+			L += get_contents(C)
+
 		return L
 
 	else
@@ -370,6 +374,10 @@ default behaviour is:
 			L += D.wrapped
 			if(istype(D.wrapped, /obj/item/storage)) //this should never happen
 				L += get_contents(D.wrapped)
+
+		for(var/obj/item/clothing/C in src.contents)	//Check for pockets and shoe knifes
+			L += get_contents(C)
+
 		return L
 
 /mob/living/proc/check_contents_for(A)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -354,8 +354,17 @@ default behaviour is:
 			if(istype(D.wrapped, /obj/item/storage)) //this should never happen
 				L += get_contents(D.wrapped)
 
-		for(var/obj/item/clothing/C in Storage.return_inv())//Check for pockets and shoe knifes
-			L += get_contents(C)
+		// Eclipse edits
+		for(var/obj/item/clothing/R in Storage.return_inv())//Check for pockets and shoe knifes
+			L += get_contents(R)
+
+		for(var/obj/item/rig/R in Storage.return_inv()) //Check for rig modules basically
+			L += get_contents(R)
+
+		for(var/obj/item/rig_module/RM in Storage.return_inv()) //Check stuff in rig storage
+			L += RM.get_contents(RM)
+
+		// End of Eclipse edit
 
 		return L
 
@@ -375,9 +384,17 @@ default behaviour is:
 			if(istype(D.wrapped, /obj/item/storage)) //this should never happen
 				L += get_contents(D.wrapped)
 
+		// Eclipse edits
 		for(var/obj/item/clothing/C in src.contents)	//Check for pockets and shoe knifes
 			L += get_contents(C)
 
+		for(var/obj/item/rig/R in src.contents) //Check for rig modules basically
+			L += get_contents(R)
+
+		for(var/obj/item/rig_module/RM in src.contents) //Check stuff in rig storage
+			L += get_contents(RM)
+
+		//End of Eclipse edit
 		return L
 
 /mob/living/proc/check_contents_for(A)


### PR DESCRIPTION
## About The Pull Request
closes #455

Fixes oddies that are put in a shoe or vest not being detectable via the inspiration system

## Why It's Good For The Game

No longer does shoving a oddity into a normal interaction with a normal system punish you for not knowing that clothing pier to this change are scanned for "are you holding something?"

This also has been updated for rig storage units.

## Testing

Disclamer this was tested on Soj with a same pr being made, as for testing on soj i had slamed a knife in a bst boot and then drank beer and leveled up using it well having a puff jacket with a coin as a "does this work for everything"
Put a coin oddity in a rig in hand, then a knife in a storage unit in back rig then a 2nd coin in a second rig in hand, leveled up saw all 3 in the menu and working.


## Changelog
:cl: Trilby
fix: oddities put in clothing and rigs are now used when focusing on an oddity
/:cl:
