### PR TITLE
Fixes autolathen mater douping

### DIFF
--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -586,7 +586,7 @@
 					if(stack.get_amount() < 1) //This stops users from putting in only half of a material.
 						to_chat(user, SPAN_NOTICE("\The [src] only takes full sheets of materials!"))
 						return
-					total_material *= stack.get_amount()
+					total_material = stack.get_amount()
 
 				if(stored_material[material] + total_material > storage_capacity)
 					total_material = storage_capacity - stored_material[material]

--- a/code/game/machinery/autolathe/autolathe.dm
+++ b/code/game/machinery/autolathe/autolathe.dm
@@ -586,7 +586,7 @@
 					if(stack.get_amount() < 1) //This stops users from putting in only half of a material.
 						to_chat(user, SPAN_NOTICE("\The [src] only takes full sheets of materials!"))
 						return
-					total_material = stack.get_amount()
+					total_material = stack.get_amount() // Eclipse edit
 
 				if(stored_material[material] + total_material > storage_capacity)
 					total_material = storage_capacity - stored_material[material]


### PR DESCRIPTION

## About The Pull Request

closes #1774
Fixes douping mater via directly adding matter into printers

## Why It's Good For The Game

V_V Lament, Mourn, and Despair V_V

## Testing

Ran a test server, clicked direct recycle with a stack of 5 plasteel then saw it add 5 rather 25. Added a welder, got correct matter and chems, then wires and also got correct matter

## Changelog
:cl:
fix: fixes autolathe matter douping 
/:cl:
