### PR TITLE
Adds configuration options for the shield generator

### DIFF
--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -218,7 +218,7 @@
 		_temp_data = config.shieldgen_heat_scalar
 		shieldgen_heat_scalar = 1
 		spawn(0)
-			throw EXCEPTION("invalid configuration value: 'SHIELDGEN_HEAT_MULTIPLIER' requires a positive number as its value. Entry [_temp_data : "of [_temp_data]" : "of a non-number"] is not valid.")
+			throw EXCEPTION("invalid configuration value: 'SHIELDGEN_HEAT_MULTIPLIER' requires a positive number as its value. Entry [_temp_data ? "of [_temp_data]" : "of a non-number"] is not valid.")
 
 	if(_config_error)
 		spawn(25 SECONDS)

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -3,7 +3,7 @@
 // RSpitzer 2020-04-18
 //
 
-#define CURRENT_CONFIG_VERSION 9
+#define CURRENT_CONFIG_VERSION 10
 
 /datum/configuration
 //For things that require delaying until the config loads for things (e.g. the
@@ -53,6 +53,10 @@
 	var/ntdad_level8_ping_sec = FALSE
 	var/ntdad_level8_ping_all = FALSE
 	var/ntdad_periodic_ongoing_round_pings = FALSE
+	
+// Shield generator
+	var/shieldgen_disable_heat = FALSE
+	var/shieldgen_heat_scalar = 1
 	
 // Miscellany.
 	var/generate_ghost_icons = FALSE		//Should we generate ghost icons?
@@ -160,7 +164,11 @@
 			if("ship_name")
 				station_name = value
 			if("vermin_limiter")
-				config.maximum_vermin = value
+				config.maximum_vermin = text2num(value)
+			if("disable_shieldgen_heat_generation")
+				config.shieldgen_disable_heat = TRUE
+			if("shieldgen_heat_multiplier")
+				config.shieldgen_heat_scalar = text2num(value)
 
 //Version check, warns if the configuration file is updated and the sysop hasn't updated their copy.
 	if(!config.eclipse_config_version)
@@ -204,6 +212,13 @@
 		config.maximum_vermin = 250		//A low number, just in case.
 		spawn(0)
 			throw EXCEPTION("invalid configuration value: 'VERMIN_LIMITER' requires a positive number or zero as its value. Entry [_temp_data ? "of [_temp_data]" : "of a non-number"] is not valid.")
+	
+	if(!isnum(config.shieldgen_heat_scalar) || config.shieldgen_heat_scalar <= 0)
+		_config_error = TRUE
+		_temp_data = config.shieldgen_heat_scalar
+		shieldgen_heat_scalar = 1
+		spawn(0)
+			throw EXCEPTION("invalid configuration value: 'SHIELDGEN_HEAT_MULTIPLIER' requires a positive number as its value. Entry [_temp_data : "of [_temp_data]" : "of a non-number"] is not valid.")
 
 	if(_config_error)
 		spawn(25 SECONDS)

--- a/code/controllers/configuration_eclipse.dm
+++ b/code/controllers/configuration_eclipse.dm
@@ -218,7 +218,7 @@
 		_temp_data = config.shieldgen_heat_scalar
 		shieldgen_heat_scalar = 1
 		spawn(0)
-			throw EXCEPTION("invalid configuration value: 'SHIELDGEN_HEAT_MULTIPLIER' requires a positive number as its value. Entry [_temp_data ? "of [_temp_data]" : "of a non-number"] is not valid.")
+			throw EXCEPTION("invalid configuration value: 'SHIELDGEN_HEAT_MULTIPLIER' requires a positive number as its value. Entry [isnull(_temp_data) ? "of a non-number" : "of [_temp_data]"] is not valid.")
 
 	if(_config_error)
 		spawn(25 SECONDS)

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -368,7 +368,7 @@
 
 	// // // BEGIN ECLIPSE EDITS // // //
 	// This is the part where we put out heat.
-	if(_safety)		//We still have our safety variable...
+	if(_safety && !config.shieldgen_disable_heat)		//We still have our safety variable...
 		var/transfer_moles = 0.79 * MOLES_CELLSTANDARD * 2		//I imagine the generator's gotta be lorg.
 		//Also, process only happens every 2 seconds, hence the *2 at the end there.
 		var/datum/gas_mixture/intake = environment.remove(transfer_moles)		//Sucked up by the intake...
@@ -388,7 +388,7 @@
 			var/normal_power_thermal_energy = (power_usage * (100-coefficient_of_performance) * (0.75 + (_working * 0.25)) * 0.25)
 			var/upkeep_power_thermal_energy = (upkeep_power_usage * (100-coefficient_of_performance) * 3)
 
-			intake.add_thermal_energy(normal_power_thermal_energy + upkeep_power_thermal_energy)
+			intake.add_thermal_energy((normal_power_thermal_energy + upkeep_power_thermal_energy) * config.shieldgen_heat_scalar) 
 			
 			egt = intake.temperature
 			//and now we exhaust the air back out.

--- a/config/example/config_eclipse.txt
+++ b/config/example/config_eclipse.txt
@@ -1,7 +1,7 @@
 # Eclipse-specific configurations, for downstream servers and dev environments.
 
 ## Configuration file version.
-CONFIG_FILE_VERSION 9
+CONFIG_FILE_VERSION 10
 
 #########
 # JOB WHITELISTING
@@ -157,6 +157,22 @@ DISPATCHER_MINIMUM_ONGOING_ROUND 5
 ## Uncomment to enable.
 ## WARNING: This option is mutually exclusive with the option immediately above.
 # DISPATCHER_MESSAGES_ALL_ON_HIVEMIND
+
+##########
+# SHIELD GENERATORS
+##########
+
+## HEAT GENERATION MASTER DISABLE
+## Do we need to disable heat generation on the ship's shields?
+## Uncomment to disable.
+# DISABLE_SHIELDGEN_HEAT_GENERATION
+
+## HEAT GENERATION SCALAR
+## How much heat should the shield generator put out? This is a flat multiplier
+## to the amount of "heat energy" that is added, and should be adjusted with
+## great care. A value of 2 is 200%, a value of 0.5 is 50%, and so forth.
+## Default: 1
+SHIELDGEN_HEAT_MULTIPLIER 1
 
 ##########
 # MISCELLANY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds config options for the shield generator's heat generation mechanic. These include...
- A master disable switch
- A flat, adjustable multiplier

these are `DISABLE_SHIELDGEN_HEAT_GENERATION` and `SHIELDGEN_HEAT_MULTIPLIER`, respectively

affects #1806 but does not properly fix it

## Why It's Good For The Game

stopgap fix until we can work in mapping changes

## Testing

Runtime tested. Shield generator disable and heat multipliers appear to work as intended.

## Changelog
:cl: eviljackcarver
add: added config options for the shield generator's heat mechanic
config: eclipse config updated to version 10
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->

---

~~it literally took longer to get tortoisegit working properly than it did to code and test.~~