### PR TITLE
Shield generator room update, basic semiotic signage pass

### DIFF
--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -166,8 +166,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/range)
@@ -1114,6 +1113,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/semiotic/airlock,
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/armory)
 "acK" = (
@@ -1487,8 +1487,7 @@
 /area/eris/security/prison)
 "adC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 10;
-	icon_state = "intact"
+	dir = 10
 	},
 /obj/machinery/camera/network/prison,
 /obj/machinery/light_switch{
@@ -2260,9 +2259,7 @@
 /turf/simulated/floor/wood,
 /area/eris/command/commander)
 "afv" = (
-/obj/structure/closet/secure_closet/reinforced/hos{
-	name = "Aegis Commander locker"
-	},
+/obj/structure/closet/secure_closet/reinforced/hos,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/eris/command/commander)
@@ -10970,6 +10967,10 @@
 	dir = 1;
 	tag = "icon-railing0 (NORTH)"
 	},
+/obj/structure/sign/semiotic/storage{
+	pixel_x = 6;
+	pixel_y = -24
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
 "azk" = (
@@ -12265,6 +12266,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/sign/semiotic/ladder{
+	pixel_x = 6;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
@@ -15366,6 +15371,7 @@
 	pixel_x = 25;
 	pixel_y = -28
 	},
+/obj/effect/floor_decal/semiotic/bulkhead_door,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/maintenance/junk)
 "aKy" = (
@@ -21745,6 +21751,15 @@
 /area/eris/hallway/side/eschangara)
 "aZd" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/sign/semiotic/directions{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/structure/sign/semiotic/bulkhead{
+	pixel_x = 4;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/podbay)
 "aZe" = (
@@ -24871,7 +24886,6 @@
 "bfa" = (
 /obj/structure/closet/wardrobe/color/grey,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/spawner/lowkeyrandom,
@@ -25167,7 +25181,6 @@
 /area/eris/maintenance/disposal)
 "bfP" = (
 /obj/machinery/computer/cryopod{
-	density = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/steel,
@@ -25394,8 +25407,7 @@
 "bgs" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -25530,8 +25542,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep/cryo)
@@ -26304,6 +26315,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/effect/floor_decal/semiotic/hazard,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/hallway/side/atmosphericshallway)
 "biA" = (
@@ -28797,7 +28809,6 @@
 "bnC" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -26
 	},
 /turf/simulated/floor/tiled/steel,
@@ -29012,9 +29023,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep/cryo)
@@ -31952,9 +31961,7 @@
 /turf/simulated/floor/plating,
 /area/eris/rnd/lab)
 "bvs" = (
-/obj/machinery/sorter/biomatter{
-	accept_output_side = 8
-	},
+/obj/machinery/sorter/biomatter,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/maintenance/section3deck5starboard)
 "bvt" = (
@@ -33464,6 +33471,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/floor_decal/semiotic/maint,
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/storage)
 "byG" = (
@@ -33751,6 +33759,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/semiotic/storage,
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section4)
 "bzp" = (
@@ -34162,6 +34171,14 @@
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/sign/semiotic/cryo{
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/obj/structure/sign/semiotic/directions{
+	pixel_x = -6;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/cryo)
@@ -35075,6 +35092,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/floor_decal/semiotic/ladder,
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section4)
 "bCt" = (
@@ -36845,8 +36863,7 @@
 /area/eris/maintenance/substation/section4)
 "bGu" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/surgery)
@@ -37481,6 +37498,10 @@
 "bHK" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/sign/semiotic/hazard{
+	pixel_x = -24;
+	pixel_y = 6
+	},
 /turf/simulated/open,
 /area/eris/engineering/atmos)
 "bHL" = (
@@ -40040,7 +40061,6 @@
 "bMZ" = (
 /obj/structure/cryofeed{
 	dir = 4;
-	icon_state = "cryo_rear";
 	tag = "icon-cryo_rear (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -40385,6 +40405,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/floor_decal/semiotic/storage,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/drone_fabrication)
 "bNK" = (
@@ -41633,8 +41654,7 @@
 /area/eris/maintenance/section1deck3central)
 "bQx" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/neotheology/chapelritualroom)
@@ -43086,6 +43106,10 @@
 /obj/machinery/camera/network/third_section{
 	dir = 4
 	},
+/obj/structure/sign/semiotic/maintenance{
+	pixel_x = -24;
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/bioreactor)
 "bTI" = (
@@ -44028,8 +44052,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -44161,12 +44184,10 @@
 /area/eris/rnd/server)
 "bWs" = (
 /obj/machinery/cryopod{
-	dir = 8;
 	icon_state = "cryopod_0";
 	tag = "icon-cryopod_0 (EAST)"
 	},
 /obj/machinery/computer/cryopod{
-	density = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -44679,7 +44700,6 @@
 /area/eris/security/lobby)
 "bXz" = (
 /obj/machinery/cryopod{
-	dir = 8;
 	icon_state = "cryopod_0";
 	tag = "icon-cryopod_0 (EAST)"
 	},
@@ -47329,6 +47349,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/sign/semiotic/maintenance{
+	pixel_x = -6;
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/neotheology/storage)
 "cdT" = (
@@ -47519,6 +47543,15 @@
 /area/eris/quartermaster/hangarsupply)
 "ceg" = (
 /obj/machinery/light,
+/obj/structure/sign/semiotic/bridge{
+	pixel_x = -6;
+	pixel_y = -24
+	},
+/obj/structure/sign/semiotic/directions{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/security/lobby)
 "ceh" = (
@@ -52828,6 +52861,9 @@
 /obj/machinery/camera/network/engineering{
 	dir = 4
 	},
+/obj/structure/sign/semiotic/high_radiation{
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/engineering/engine_room)
 "cqt" = (
@@ -55742,9 +55778,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -55755,6 +55788,15 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/sign/semiotic/bridge{
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/structure/sign/semiotic/directions{
+	dir = 1;
+	pixel_x = -6;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/hallway/side/bridgehallway)
@@ -55917,8 +55959,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
@@ -60081,8 +60122,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
@@ -60732,8 +60772,7 @@
 /area/eris/maintenance/section2deck2starboard)
 "cIH" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -61200,8 +61239,7 @@
 "cJO" = (
 /obj/structure/cyberplant,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/sleep/cryo)
@@ -67772,6 +67810,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/floor_decal/semiotic/storage,
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/eris/rnd/research)
 "cZx" = (
@@ -71861,8 +71900,7 @@
 	dir = 4
 	},
 /obj/machinery/button/windowtint{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/wood,
 /area/eris/command/meo/quarters)
@@ -75081,6 +75119,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/sign/semiotic/no_grav_no_press{
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/obj/structure/sign/semiotic/directions{
+	pixel_x = -24;
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/maintenance/junk)
 "dpF" = (
@@ -75099,6 +75145,10 @@
 /area/eris/medical/medeva)
 "dpI" = (
 /obj/landmark/storyevent/hidden_vent_antag,
+/obj/structure/sign/semiotic/bulkhead{
+	pixel_x = 4;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/white/techfloor,
 /area/eris/medical/medeva)
 "dpJ" = (
@@ -76468,7 +76518,6 @@
 /area/eris/engineering/propulsion/left)
 "dsI" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -76591,7 +76640,6 @@
 "dsW" = (
 /obj/machinery/light,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78106,6 +78154,10 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/structure/sign/semiotic/storage{
+	pixel_x = 24;
+	pixel_y = -6
+	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/medbay/uppercor)
 "dwr" = (
@@ -82606,6 +82658,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/floor_decal/semiotic/airlock,
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
 "dHe" = (
@@ -83968,6 +84021,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/floor_decal/semiotic/maint,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/engineering/propulsion/left)
 "dJH" = (
@@ -84059,6 +84113,14 @@
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/sign/semiotic/storage{
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/structure/sign/semiotic/suit{
+	pixel_x = -6;
+	pixel_y = 24
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/docking)
@@ -85713,6 +85775,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/effect/floor_decal/semiotic/bulkhead_door,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
 "dNx" = (
@@ -86286,15 +86349,14 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
 "dOT" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
 "dOU" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
@@ -86425,6 +86487,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/structure/sign/semiotic/high_radiation{
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/gravity_generator)
 "dPp" = (
@@ -86515,9 +86580,7 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPz" = (
-/obj/item/modular_computer/console/preset/engineering/shield{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPA" = (
@@ -86525,6 +86588,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4;
+	tag = "icon-intact (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/shield_generator)
@@ -86549,16 +86616,20 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
 "dPE" = (
-/obj/structure/table/standard,
-/obj/item/storage/toolbox/mechanical,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 10;
+	tag = "icon-intact (NORTHWEST)"
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPF" = (
-/obj/machinery/alarm{
+/obj/machinery/alarm/nobreach{
 	dir = 4;
-	pixel_x = -22
+	pixel_x = -24
 	},
-/obj/structure/table/standard,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPG" = (
@@ -86567,32 +86638,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/shield_generator)
 "dPH" = (
-/obj/structure/table/standard,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/item/device/radio,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "East APC";
-	pixel_x = 28
-	},
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/unary/vent_pump/siphon/on{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPI" = (
-/obj/structure/table/standard,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -86836,12 +86890,10 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/shield_generator)
 "dQm" = (
-/obj/structure/table/standard,
-/obj/item/cell/large/high,
-/obj/item/cell/large/high,
 /obj/machinery/button/remote/blast_door{
 	id = "shieldroom";
-	name = "Shield Generator Shutters"
+	name = "Shield Generator Shutters";
+	pixel_x = 23
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
@@ -87256,11 +87308,9 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
 /obj/machinery/button/remote/blast_door{
-	dir = 2;
 	id = "maint_hatch_lower_cargo";
 	name = "Maintenance Hatch Control";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plating,
@@ -87550,10 +87600,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/hangarsupply)
-"dRQ" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/steel/techfloor,
-/area/eris/engineering/shield_generator)
 "dRR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -88107,7 +88153,6 @@
 /area/eris/engineering/atmos)
 "dTf" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "South APC";
 	pixel_y = -28
 	},
@@ -89135,11 +89180,9 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
 /obj/machinery/button/remote/blast_door{
-	dir = 2;
 	id = "maint_hatch_lower_cargo";
 	name = "Maintenance Hatch Control";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access = null
 	},
 /turf/simulated/floor/plating,
@@ -89686,6 +89729,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/floor_decal/semiotic/bridge,
 /turf/simulated/floor/tiled/dark,
 /area/eris/command/meeting_room)
 "dWP" = (
@@ -89716,6 +89760,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/semiotic/bridge,
 /turf/simulated/floor/tiled/dark,
 /area/eris/command/meeting_room)
 "dWU" = (
@@ -90445,6 +90490,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/floor_decal/semiotic/suit/alt,
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
 "dYr" = (
@@ -91559,8 +91605,7 @@
 /area/eris/rnd/anomalisoltwo)
 "ebc" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck1central)
@@ -99093,7 +99138,7 @@
 "esH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
-	name = "Generator Room";
+	name = "Shield Generator Room";
 	req_access = list(10)
 	},
 /obj/structure/cable/green{
@@ -102591,9 +102636,6 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "ezX" = (
-/obj/structure/bed/chair{
-	dir = 8
-	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
 "ezY" = (
@@ -103413,6 +103455,13 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/gravity_generator)
 "eBC" = (
@@ -103782,11 +103831,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/gravity_generator)
@@ -103860,6 +103907,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
+/obj/structure/sign/semiotic/high_radiation{
+	pixel_x = 24
+	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
 "eCw" = (
@@ -104586,6 +104636,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/semiotic/rad_hazard,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/gravity_generator)
 "eEi" = (
@@ -105918,14 +105969,14 @@
 /area/eris/engineering/propulsion/right)
 "eQb" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
 "eQd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
@@ -106172,6 +106223,15 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"fAw" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/regular{
+	id = "shieldroom";
+	name = "Shield Generator Screen"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/space)
 "fBx" = (
 /obj/machinery/holomap{
 	dir = 4;
@@ -106464,8 +106524,7 @@
 /area/eris/engineering/construction)
 "gGt" = (
 /obj/item/modular_computer/console/preset/engineering/power{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
@@ -106540,6 +106599,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
+"gYO" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "hcV" = (
 /obj/structure/bed/chair/comfy/beige,
 /obj/machinery/light{
@@ -106780,6 +106845,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/eschangarb)
+"iaH" = (
+/obj/structure/sign/semiotic/high_radiation{
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/eris/engineering/gravity_generator)
 "icN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
@@ -106797,9 +106868,9 @@
 	frequency = 1379;
 	master_tag = "trading_dock";
 	name = "Trading Dock Internal Access Button";
-	pixel_x = 0;
 	pixel_y = 24
 	},
+/obj/effect/floor_decal/semiotic/airlock,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "ifg" = (
@@ -106863,6 +106934,12 @@
 "iqF" = (
 /turf/simulated/floor/tiled/dark,
 /area/eris/command/bridgetoilet)
+"iqG" = (
+/obj/item/modular_computer/console/preset/engineering/shield{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/space)
 "iqV" = (
 /obj/structure/lattice,
 /turf/simulated/floor/hull,
@@ -106996,6 +107073,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
+"iVJ" = (
+/obj/effect/floor_decal/semiotic/storage,
+/turf/simulated/floor/tiled/steel,
+/area/eris/crew_quarters/sleep/cryo)
 "iXv" = (
 /obj/effect/shuttle_landmark/merc/engine,
 /turf/space,
@@ -107085,7 +107166,6 @@
 /area/eris/hallway/side/eschangarb)
 "jnC" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "trading_dock_internal_sensor";
 	name = "Internal Trading Dock Airlock Sensor";
 	pixel_x = -5;
@@ -107154,6 +107234,14 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
+"jxG" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8;
+	tag = "icon-danger (WEST)"
+	},
+/obj/effect/floor_decal/semiotic/electronics,
+/turf/simulated/floor/tiled/white,
+/area/eris/rnd/mixing)
 "jzc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark/panels,
@@ -107187,6 +107275,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/medical/chemstor)
+"jEe" = (
+/obj/effect/floor_decal/semiotic/ladder,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section4deck1central)
 "jGP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -107204,6 +107296,17 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
+"jHS" = (
+/obj/structure/table/standard,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/space)
 "jIq" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -107299,6 +107402,21 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/command/bridgebar)
+"kfD" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/sign/semiotic/intercom{
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/obj/structure/sign/semiotic/directions{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/steel/bluecorner,
+/area/eris/hallway/side/bridgehallway)
 "kfX" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -107407,6 +107525,17 @@
 /obj/machinery/vending/serbomat,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/hallway/main/section2)
+"kGL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "kHZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
@@ -107446,6 +107575,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/command/mbo)
+"kUz" = (
+/obj/structure/sign/semiotic/hazard{
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark/golden,
+/area/eris/neotheology/bioreactor)
 "kUI" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -107529,6 +107665,18 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
+"lfN" = (
+/obj/machinery/door/blast/regular{
+	id = "shieldroom";
+	name = "Shield Generator Screen"
+	},
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
+	dir = 4;
+	tag = "icon-intact (EAST)"
+	},
+/turf/simulated/floor/plating,
+/area/eris/engineering/shield_generator)
 "lgO" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/ears/earmuffs,
@@ -107733,6 +107881,16 @@
 	},
 /turf/simulated/floor/grass,
 /area/eris/crew_quarters/hydroponics/garden)
+"lLK" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/semiotic/ladder{
+	pixel_x = -24;
+	pixel_y = -6
+	},
+/turf/simulated/floor/tiled/steel,
+/area/eris/hallway/main/section3)
 "lMs" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/tiled/techmaint,
@@ -107747,8 +107905,7 @@
 /area/eris/maintenance/section2deck5starboard)
 "lPs" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
@@ -107871,7 +108028,6 @@
 	},
 /obj/machinery/shield_diffuser,
 /obj/machinery/airlock_sensor/shuttle_exterior{
-	frequency = 1379;
 	id_tag = "trading_dock_external_sensor";
 	name = "external trading dock sensor";
 	pixel_y = -24;
@@ -108020,6 +108176,21 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/quartermaster/hangarsupply)
+"mCb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Shield Generator Control Room";
+	req_access = list(10)
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/eris/engineering/gravity_generator)
 "mCf" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -108082,6 +108253,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/hull,
 /area/eris/engineering/breakroom)
+"mJb" = (
+/obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "mKR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -108116,6 +108291,10 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
+"mUg" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/space)
 "mUB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -108263,6 +108442,23 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/medical/chemistry)
+"nBj" = (
+/obj/machinery/button/remote/blast_door{
+	dir = 1;
+	id = "shieldroom";
+	name = "Shield Generator Shutters";
+	pixel_x = 5;
+	pixel_y = -21
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
+"nEM" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "nFL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -108321,6 +108517,13 @@
 "nNw" = (
 /turf/simulated/wall/r_wall,
 /area/eris/engineering/long_range_scanner)
+"nNN" = (
+/obj/structure/sign/semiotic/storage{
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/eris/engineering/atmos)
 "nQt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -108446,6 +108649,16 @@
 	tag = "icon-cargofloor7"
 	},
 /area/eris/hallway/side/eschangara)
+"odD" = (
+/obj/machinery/atmospherics/binary/pump/high_power{
+	dir = 4;
+	name = "Radiator to Cooling Loop"
+	},
+/obj/structure/sign/semiotic/high_radiation{
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/eris/engineering/engine_room)
 "oft" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -108476,6 +108689,13 @@
 	tag = "icon-cargofloor7"
 	},
 /area/eris/hallway/side/eschangara)
+"ory" = (
+/obj/structure/table/standard,
+/obj/item/cell/large/high,
+/obj/item/cell/large/high,
+/obj/item/cell/large/high,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/space)
 "orW" = (
 /obj/spawner/scrap,
 /turf/simulated/shuttle/floor{
@@ -108735,6 +108955,12 @@
 /obj/item/storage/freezer/medical,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/surgery)
+"oUN" = (
+/obj/structure/sign/semiotic/high_radiation{
+	pixel_x = 24
+	},
+/turf/simulated/floor/tiled/dark/danger,
+/area/eris/engineering/gravity_generator)
 "oVb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -108806,6 +109032,17 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
+"pqK" = (
+/obj/machinery/power/apc{
+	name = "South APC";
+	pixel_y = -28
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "pto" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/reinforced/polarized,
@@ -108905,7 +109142,6 @@
 /obj/machinery/airlock_sensor{
 	id_tag = "trading_port_airlock_sensor";
 	name = "Trading Port Airlock Sensor";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/steel,
@@ -108938,6 +109174,12 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
+"pVd" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "pWC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/bed/chair/wood{
@@ -109006,6 +109248,12 @@
 	icon_state = "cargofloor1"
 	},
 /area/eris/hallway/side/eschangarb)
+"qns" = (
+/obj/machinery/atmospherics/binary/pump{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "qnS" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = -32
@@ -109070,6 +109318,20 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/security/checkpoint/supply)
+"qyL" = (
+/obj/structure/table/standard,
+/obj/item/device/radio,
+/obj/machinery/camera/network/engineering{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/space)
+"qzr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "qBj" = (
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
@@ -109093,6 +109355,9 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/hangarsupply)
+"qKd" = (
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/space)
 "qOD" = (
 /obj/structure/showcase{
 	desc = "Ancient robotic frame, that is long deactivated and rusted solid. However, it still strikes am awesome pose, that somehow makes you think of justice and righteousness.";
@@ -109125,6 +109390,15 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/surgery)
+"qUu" = (
+/obj/structure/table/standard,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/space)
 "qUV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -109444,6 +109718,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /turf/simulated/wall/r_wall,
 /area/eris/crew_quarters/fitness)
+"rWa" = (
+/obj/effect/floor_decal/semiotic/storage,
+/turf/simulated/floor/tiled/dark,
+/area/eris/security/warden)
 "rXZ" = (
 /mob/living/simple_animal/cat/fluff/bones,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -109562,8 +109840,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -109581,8 +109858,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
@@ -109757,6 +110033,10 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
+"sRP" = (
+/obj/effect/floor_decal/semiotic/airlock,
+/turf/simulated/floor/tiled/white,
+/area/eris/rnd/docking)
 "sRW" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -109767,6 +110047,9 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
+"sWq" = (
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "sXb" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/railing/grey{
@@ -109800,6 +110083,15 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/warden)
+"tcl" = (
+/obj/machinery/door/blast/regular{
+	id = "shieldroom";
+	name = "Shield Generator Screen"
+	},
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/eris/engineering/shield_generator)
 "tdm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4;
@@ -109817,6 +110109,18 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"tlV" = (
+/obj/structure/sign/semiotic/bulkhead{
+	pixel_x = 4;
+	pixel_y = 24
+	},
+/obj/structure/sign/semiotic/directions{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/steel,
+/area/eris/crew_quarters/fitness)
 "tnB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -109951,15 +110255,19 @@
 	dir = 1
 	},
 /obj/machinery/vending/snack,
+/obj/structure/sign/semiotic/galley{
+	pixel_x = 6;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "uaP" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
 	},
-/turf/simulated/floor/tiled/steel,
-/area/eris/crew_quarters/fitness)
+/turf/simulated/wall/r_wall,
+/area/eris/command/tcommsat/chamber)
 "ubu" = (
 /obj/machinery/holomap{
 	pixel_y = 32
@@ -110273,6 +110581,16 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/engine_room)
+"vbX" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/sign/semiotic/airlock{
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/white,
+/area/eris/rnd/docking)
 "vdS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera/network/third_section{
@@ -110419,6 +110737,14 @@
 /obj/structure/railing/grey,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/hangarsupply)
+"vzx" = (
+/obj/machinery/light,
+/obj/structure/sign/semiotic/ladder{
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/steel,
+/area/eris/hallway/main/section3)
 "vAE" = (
 /turf/simulated/wall/r_wall,
 /area/eris/crew_quarters/clownoffice)
@@ -110587,6 +110913,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
+"wfo" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5;
+	tag = "icon-intact (NORTHEAST)"
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "wgR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -110614,6 +110947,33 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
+"wmj" = (
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/obj/structure/sign/semiotic/storage{
+	pixel_x = -24;
+	pixel_y = 6
+	},
+/obj/structure/sign/semiotic/directions{
+	dir = 8;
+	pixel_x = -24;
+	pixel_y = -6
+	},
+/turf/simulated/floor/tiled/steel/danger,
+/area/eris/engineering/engine_room)
+"wmX" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "wns" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -110655,9 +111015,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1";
-	pixel_y = 0
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
@@ -110669,6 +111027,10 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"wrg" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/space)
 "wui" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -110740,6 +111102,18 @@
 /obj/structure/sign/department/medbay,
 /turf/simulated/wall,
 /area/eris/medical/medbay/organs)
+"wVo" = (
+/obj/structure/sign/semiotic/electronics{
+	pixel_x = -6;
+	pixel_y = -24
+	},
+/obj/structure/sign/semiotic/directions{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/steel/bluecorner,
+/area/eris/hallway/side/bridgehallway)
 "wWI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -110885,12 +111259,17 @@
 /obj/structure/table/reinforced,
 /obj/machinery/button/remote/blast_door{
 	id = "trading_lockddown";
-	name = "Trading Dock Lockdown Control";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Trading Dock Lockdown Control"
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/security/checkpoint/supply)
+"xDe" = (
+/obj/structure/sign/semiotic/storage{
+	pixel_x = 24;
+	pixel_y = 6
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section4deck1central)
 "xDm" = (
 /obj/structure/table/standard,
 /obj/machinery/button/remote/blast_door{
@@ -111019,6 +111398,18 @@
 "xWH" = (
 /turf/simulated/wall,
 /area/eris/command/bridgetoilet)
+"xXw" = (
+/obj/structure/sign/semiotic/radiation_hazard{
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/obj/structure/sign/semiotic/directions{
+	dir = 8;
+	pixel_x = -6;
+	pixel_y = -24
+	},
+/turf/simulated/floor/tiled/steel/techfloor,
+/area/eris/engineering/engine_room)
 "xZK" = (
 /obj/structure/multiz/stairs/enter{
 	dir = 4
@@ -128980,7 +129371,7 @@ aID
 aJS
 aLh
 aGq
-aGr
+nNN
 aMt
 aRl
 aOc
@@ -129158,7 +129549,7 @@ bYQ
 bZS
 ccw
 aCn
-bts
+kUz
 ceR
 aCn
 kEW
@@ -170807,7 +171198,7 @@ bON
 bfa
 hNy
 bTh
-bfA
+iVJ
 bfA
 blV
 bfA
@@ -172625,7 +173016,7 @@ bON
 bfa
 qnS
 bTh
-bfA
+iVJ
 bfA
 blV
 bfA
@@ -172715,7 +173106,7 @@ aaB
 aaK
 aaJ
 aYv
-aaJ
+rWa
 aaJ
 aTR
 tbl
@@ -205136,7 +205527,7 @@ cnT
 cnw
 eEt
 cQL
-cpA
+wmj
 cSP
 bIP
 bIP
@@ -206543,7 +206934,7 @@ abF
 bIP
 bIP
 bIP
-cMk
+odD
 cMk
 cMk
 cPi
@@ -211764,7 +212155,7 @@ cpe
 cpe
 bZc
 chY
-dTS
+lLK
 cpo
 dGT
 dhR
@@ -212389,7 +212780,7 @@ cpo
 cpo
 ewy
 cpo
-etu
+vzx
 chY
 ewS
 cpo
@@ -215583,7 +215974,7 @@ ces
 bWC
 ckm
 chi
-cjb
+jxG
 cjb
 cjb
 cjb
@@ -246348,7 +246739,7 @@ dBf
 tdm
 dQI
 eEt
-eEt
+xXw
 bIP
 dRD
 dEy
@@ -246715,7 +247106,7 @@ dqI
 ecP
 eal
 awr
-cDi
+tlV
 cDi
 cmE
 dvt
@@ -247119,7 +247510,7 @@ awr
 dkH
 cDi
 cDi
-uaP
+euy
 cDi
 cmE
 cmE
@@ -248282,7 +248673,7 @@ aaa
 aaa
 aaa
 bYo
-bYo
+uaP
 bYo
 bYo
 bYo
@@ -251116,7 +251507,7 @@ cWD
 cWD
 bXj
 cxa
-cCT
+kfD
 dkD
 dkY
 dlz
@@ -251520,7 +251911,7 @@ cWD
 cWD
 bXj
 cxg
-ctW
+wVo
 dkD
 dla
 dlS
@@ -251722,7 +252113,7 @@ dbF
 dbF
 cWD
 cxl
-ctW
+cIF
 dkD
 dlb
 dmd
@@ -255229,7 +255620,7 @@ dLg
 dki
 dki
 dqs
-dki
+iaH
 dki
 dLg
 dMc
@@ -256441,7 +256832,7 @@ dLg
 dki
 dki
 dqz
-dki
+oUN
 dki
 dLg
 dMz
@@ -291990,9 +292381,9 @@ ehk
 ehk
 ehl
 ehs
-eho
+jEe
 eip
-eho
+xDe
 ehs
 eho
 ejM
@@ -294005,10 +294396,10 @@ dJh
 bBH
 dXi
 abF
-abF
-abF
-aaa
-aaa
+aae
+fAw
+aae
+aae
 eAj
 eAj
 eAK
@@ -294207,11 +294598,11 @@ evG
 cNH
 dXi
 abF
-abF
-abF
-aaa
-aaa
-aaa
+aae
+qKd
+qyL
+qUu
+iqG
 ehk
 eir
 eiy
@@ -294409,11 +294800,11 @@ cNH
 cNH
 dXi
 abF
-abF
-abF
-aaa
-aaa
-aaa
+aae
+qKd
+sWq
+sWq
+gYO
 ehk
 eit
 eiK
@@ -294611,11 +295002,11 @@ cNH
 eBh
 dXi
 abF
-abF
-abF
-aaa
-aaa
-aaa
+aae
+qKd
+sWq
+pVd
+pqK
 dLg
 eBz
 eAS
@@ -294813,11 +295204,11 @@ cNH
 dXi
 dXi
 abF
-abF
-abF
-aaa
-aaa
-aaa
+aae
+qKd
+nEM
+qzr
+kGL
 dLg
 dPb
 dPo
@@ -295015,12 +295406,12 @@ cNH
 dXi
 abF
 abF
-abF
-abF
-aaa
-aaa
-aaa
-dLg
+aae
+qKd
+wfo
+wrg
+wmX
+mCb
 eBB
 eCo
 eCO
@@ -295217,11 +295608,11 @@ aNe
 dXi
 abF
 abF
-abF
-abF
-aaa
-aaa
-aaa
+aae
+qKd
+mJb
+qns
+nBj
 dLg
 eBC
 eCp
@@ -295419,11 +295810,11 @@ cNH
 dXi
 abF
 abF
-abF
-abF
-aaa
-aaa
-aaa
+aae
+qKd
+mUg
+jHS
+ory
 dLg
 eBD
 eCq
@@ -295622,8 +296013,8 @@ dXi
 abF
 abF
 dKs
-ddZ
-ddZ
+tcl
+lfN
 dKs
 dKs
 dLg
@@ -296431,7 +296822,7 @@ abF
 dKs
 dKs
 dPl
-dRQ
+ezX
 dOU
 eQd
 eAS
@@ -298605,7 +298996,7 @@ bDI
 bDX
 dpg
 dJS
-dKn
+vbX
 dpg
 ebT
 ebi
@@ -299219,7 +299610,7 @@ ecx
 ecx
 dpg
 dXq
-dXy
+sRP
 dXy
 eaT
 ekx

--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -86580,7 +86580,10 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1;
+	tag = "icon-map (NORTH)"
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPA" = (
@@ -86589,9 +86592,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4;
-	tag = "icon-intact (EAST)"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/shield_generator)
@@ -86616,9 +86618,8 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
 "dPE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 10;
-	tag = "icon-intact (NORTHWEST)"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
@@ -102636,6 +102637,10 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "ezX" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 1;
+	tag = "icon-map (NORTH)"
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
 "ezY" = (
@@ -106231,7 +106236,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/space)
+/area/eris/engineering/shield_generator)
 "fBx" = (
 /obj/machinery/holomap{
 	dir = 4;
@@ -106604,7 +106609,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "hcV" = (
 /obj/structure/bed/chair/comfy/beige,
 /obj/machinery/light{
@@ -106939,7 +106944,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/space)
+/area/eris/engineering/shield_generator)
 "iqV" = (
 /obj/structure/lattice,
 /turf/simulated/floor/hull,
@@ -107306,7 +107311,7 @@
 	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/space)
+/area/eris/engineering/shield_generator)
 "jIq" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -107535,7 +107540,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "kHZ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
@@ -107671,9 +107676,8 @@
 	name = "Shield Generator Screen"
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
-/obj/machinery/atmospherics/pipe/simple/hidden/yellow{
-	dir = 4;
-	tag = "icon-intact (EAST)"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/shield_generator)
@@ -108256,7 +108260,7 @@
 "mJb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "mKR" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -108294,7 +108298,7 @@
 "mUg" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/space)
+/area/eris/engineering/shield_generator)
 "mUB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -108454,11 +108458,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "nEM" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "nFL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -108665,6 +108669,12 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/maintenance/section3deck5starboard)
+"oju" = (
+/obj/machinery/atmospherics/unary/freezer{
+	icon_state = "freezer"
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/eris/engineering/shield_generator)
 "onI" = (
 /obj/item/stool/padded,
 /turf/simulated/floor/tiled/steel,
@@ -108695,7 +108705,7 @@
 /obj/item/cell/large/high,
 /obj/item/cell/large/high,
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/space)
+/area/eris/engineering/shield_generator)
 "orW" = (
 /obj/spawner/scrap,
 /turf/simulated/shuttle/floor{
@@ -109042,7 +109052,7 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "pto" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/reinforced/polarized,
@@ -109179,7 +109189,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "pWC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/bed/chair/wood{
@@ -109253,7 +109263,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "qnS" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = -32
@@ -109325,13 +109335,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/space)
+/area/eris/engineering/shield_generator)
 "qzr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "qBj" = (
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
@@ -109356,8 +109366,11 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/hangarsupply)
 "qKd" = (
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/space)
+/area/eris/engineering/shield_generator)
 "qOD" = (
 /obj/structure/showcase{
 	desc = "Ancient robotic frame, that is long deactivated and rusted solid. However, it still strikes am awesome pose, that somehow makes you think of justice and righteousness.";
@@ -109398,7 +109411,7 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
-/area/space)
+/area/eris/engineering/shield_generator)
 "qUV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -110049,7 +110062,7 @@
 /area/eris/crew_quarters/bar)
 "sWq" = (
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "sXb" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/railing/grey{
@@ -110084,13 +110097,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/warden)
 "tcl" = (
-/obj/machinery/door/blast/regular{
-	id = "shieldroom";
-	name = "Shield Generator Screen"
-	},
-/obj/effect/window_lwall_spawn/smartspawn,
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating,
+/obj/machinery/constructable_frame/machine_frame,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "tdm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -110919,7 +110927,7 @@
 	tag = "icon-intact (NORTHEAST)"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "wgR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -110973,7 +110981,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "wns" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -111030,7 +111038,7 @@
 "wrg" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/steel/techfloor,
-/area/space)
+/area/eris/engineering/shield_generator)
 "wui" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -294396,10 +294404,10 @@ dJh
 bBH
 dXi
 abF
-aae
+dKs
 fAw
-aae
-aae
+dKs
+dKs
 eAj
 eAj
 eAK
@@ -294598,8 +294606,8 @@ evG
 cNH
 dXi
 abF
-aae
-qKd
+dKs
+dPw
 qyL
 qUu
 iqG
@@ -294800,8 +294808,8 @@ cNH
 cNH
 dXi
 abF
-aae
-qKd
+dKs
+dPw
 sWq
 sWq
 gYO
@@ -295002,8 +295010,8 @@ cNH
 eBh
 dXi
 abF
-aae
-qKd
+dKs
+dPw
 sWq
 pVd
 pqK
@@ -295204,7 +295212,7 @@ cNH
 dXi
 dXi
 abF
-aae
+dKs
 qKd
 nEM
 qzr
@@ -295406,8 +295414,8 @@ cNH
 dXi
 abF
 abF
-aae
-qKd
+dKs
+tcl
 wfo
 wrg
 wmX
@@ -295608,8 +295616,8 @@ aNe
 dXi
 abF
 abF
-aae
-qKd
+dKs
+oju
 mJb
 qns
 nBj
@@ -295810,8 +295818,8 @@ cNH
 dXi
 abF
 abF
-aae
-qKd
+dKs
+oju
 mUg
 jHS
 ory
@@ -296013,7 +296021,7 @@ dXi
 abF
 abF
 dKs
-tcl
+ddZ
 lfN
 dKs
 dKs

--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -86624,7 +86624,7 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPF" = (
-/obj/machinery/alarm/nobreach{
+/obj/machinery/alarm/monitor{
 	dir = 4;
 	pixel_x = -24
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Adds in a control room and cooling systems for the shield generator.
- Adds in a quick-and-dirty pass with the Semiotic Standard signage, for all commercial trans-stellar utility lifter and heavy element transport spacecraft.

Closes #1806 as fixed.

## Why It's Good For The Game

Shields not overheating is a good thing, yes?

## Testing

The shield generator room changes were tested in-engine to verify it would be enough to cool the system down while the generator was under active load.

![image](https://github.com/user-attachments/assets/d169e704-5be6-48b9-a028-6a980955e527)

Outside of that, all other changes have only been compiler tested.

## Changelog
:cl: EvilJackCarver
fix: shield generator room now has a proper cooling system installed.
add: Quick-and-dirty pass with Semiotic Standard signage around the ship.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
