### PR TITLE
Fixes markings

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -358,7 +358,7 @@ var/global/list/damage_icon_parts = list()
 		var/datum/sprite_accessory/marking/real_marking = body_marking_styles_list[markname]
 		var/icon/specific_marking_icon = new()
 		for(var/part in real_marking.body_parts)
-			var/valid = (part in organs_by_name) && organs_by_name[part] && ((part in BP_BASE_PARTS))
+			var/valid = (part in organs_by_name) && organs_by_name[part] && ((part in BP_ALL_LIMBS))
 			if(valid && ("[real_marking.icon_state]-[part]" in icon_states(real_marking.icon)))
 				var/icon/specific_marking_subicon = icon(real_marking.icon, "[real_marking.icon_state]-[part]")
 				specific_marking_subicon.Blend(specific_marking_icon, ICON_OVERLAY)


### PR DESCRIPTION

## About The Pull Request

closes #1804 

Why It's Good For The Game

Makes it so we can decorate are fancy snowfalkes arms and legs, even the face and head!

## Testing

![image](https://github.com/user-attachments/assets/7e698fec-bbf8-4219-86d2-7fc1200690e9)

## Changelog
:cl:
fix: Fixes markings not being valid targets for limbs other then torso
/:cl:
