### PR TITLE
Fixes shield generator temperature and annunciator readout on consoles

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/shield_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/shield_control.dm
@@ -93,6 +93,18 @@
 		data["power_usage"] = round(gen.power_usage / 1000)
 		data["offline_for"] = gen.offline_for * 2
 		data["shutdown"] = gen.emergency_shutdown
+	
+		// // // BEGIN ECLIPSE EDITS // // //
+		// Monitoring.
+		data["temp_internal"] = gen.itt
+		data["temp_exhaust"] = gen.egt
+		
+		//Thresholds, used in annunciator panel and bar colouring.
+		data["thr_cold"] = gen.threshold_cold
+		data["thr_norm"] = gen.threshold_normal
+		data["thr_crit"] = gen.threshold_critical
+		data["thr_htco"] = gen.threshold_high_temperature_cutout
+		// // // END ECLIPSE EDITS // // //
 	else
 		data["nogen"] = TRUE //Special flag so the template can tell between console and physical
 


### PR DESCRIPTION
you can now see the annunciator panel and raw temperatures without having to walk down to the generator itself

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a long-standing issue where players were unable to read the temperature displays or the annunciator panel from the Shield Control program on consoles.

## Why It's Good For The Game

Players no longer have to go into a cold room to check on the temperature of the shield generator; they can monitor it from the comfort of Blue's Recluse once more. This also means that all of the annunciators also work again, allowing players to quickly assess the state of things.

## Testing

Tested in my development environment using debugging code. Tested again with a fresh install of the dev environment with the debugging code removed. 

![image](https://github.com/user-attachments/assets/b74c5678-696c-4e6f-8cb9-68ce92471601)

## Changelog
:cl:
fix: Fixed an issue where the temperature gauges and annunciators were not properly working.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
