### PR TITLE
Fixes some atmospherics-related map issues

### DIFF
--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -2261,6 +2261,7 @@
 "afv" = (
 /obj/structure/closet/secure_closet/reinforced/hos,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/taperoll/police,
 /turf/simulated/floor/wood,
 /area/eris/command/commander)
 "afw" = (
@@ -8519,14 +8520,21 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
 "ata" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/camera/network/third_section,
+/obj/structure/sign/semiotic/bulkhead{
+	pixel_x = -8;
+	pixel_y = 24
 	},
-/turf/simulated/wall,
-/area/eris/crew_quarters/fitness)
+/obj/structure/sign/semiotic/directions{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/eris/hallway/side/section3starboard)
 "atb" = (
 /turf/simulated/wall,
 /area/eris/maintenance/fueltankstorage)
@@ -9535,13 +9543,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/hallway/side/section3starboard)
-"avK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/wood,
-/area/eris/neotheology/storage)
 "avL" = (
 /obj/structure/railing{
 	dir = 1;
@@ -9793,9 +9794,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/armory)
 "awt" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/fitness)
 "awu" = (
@@ -9838,6 +9836,10 @@
 /area/eris/maintenance/section2deck4port)
 "awA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/eschangara)
 "awB" = (
@@ -20901,6 +20903,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/taperoll/police,
+/obj/item/taperoll/police,
+/obj/item/taperoll/police,
+/obj/item/taperoll/police,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/security/barracks)
 "aXo" = (
@@ -23300,6 +23306,7 @@
 /obj/item/tank/emergency_oxygen/double,
 /obj/item/tank/emergency_oxygen/double,
 /obj/machinery/light/small,
+/obj/item/taperoll/atmos,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/engineering/atmos/storage)
 "bce" = (
@@ -27208,13 +27215,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section2)
-"bkn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/wood,
-/area/eris/neotheology/storage)
 "bko" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/spray/cleaner,
@@ -31418,11 +31418,11 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/medical/virology)
 "btZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/wood,
+/area/eris/neotheology/storage)
 "bua" = (
 /obj/structure/bed/chair/office/dark,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -32186,10 +32186,12 @@
 /area/eris/maintenance/section3deck1central)
 "bvP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/eris/neotheology/storage)
@@ -38733,6 +38735,7 @@
 /area/eris/security/inspectors_office)
 "bKm" = (
 /obj/structure/closet/secure_closet/detective,
+/obj/item/taperoll/police,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/inspectors_office)
 "bKn" = (
@@ -40669,10 +40672,7 @@
 	pixel_y = 7
 	},
 /obj/structure/table/rack,
-/turf/simulated/floor/reinforced{
-	name = "engine floor";
-	oxygen = 0
-	},
+/turf/simulated/floor/reinforced,
 /area/eris/crew_quarters/fitness)
 "bOj" = (
 /turf/simulated/floor/plating,
@@ -43787,11 +43787,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/maintenance/section1deck3central)
 "bVr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/machinery/camera/network/third_section{
 	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/eris/neotheology/storage)
@@ -45897,9 +45897,6 @@
 /area/eris/maintenance/section3deck4starboard)
 "can" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_y = 8
@@ -47599,13 +47596,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
-"cem" = (
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/eris/neotheology/storage)
 "cen" = (
 /obj/item/modular_computer/console/preset/genetics,
 /turf/simulated/floor/tiled/white,
@@ -47961,9 +47951,6 @@
 /area/eris/rnd/mixing)
 "ceU" = (
 /obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/eris/neotheology/storage)
 "ceV" = (
@@ -51829,7 +51816,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/obj/structure/reagent_dispensers/watertank/huge,
+/obj/structure/closet/crate/secure/hydrosec/prelocked,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/item/reagent_containers/dropper,
+/obj/item/tool/wrench,
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
 "cnZ" = (
@@ -54903,6 +54893,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/taperoll/research,
 /turf/simulated/floor/carpet/purcarpet,
 /area/eris/command/meo)
 "cvj" = (
@@ -55825,10 +55816,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/item/reagent_containers/glass/bottle/mutagen,
-/obj/item/reagent_containers/dropper,
-/obj/structure/closet/crate/secure/hydrosec/prelocked,
-/obj/item/tool/wrench,
+/obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
 "cxl" = (
@@ -56413,7 +56401,6 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/engineering/engine_room)
 "cyC" = (
-/obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/oldtele)
@@ -58778,9 +58765,15 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
 "cDN" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/eris/crew_quarters/fitness)
+/obj/structure/multiz/stairs/enter{
+	dir = 8
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/eris/hallway/side/eschangarb)
 "cDO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating/under,
@@ -62021,16 +62014,15 @@
 /obj/structure/table/standard,
 /obj/spawner/pack/tech_loot,
 /obj/spawner/pack/tech_loot,
-/obj/item/tape/engineering,
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
-/obj/item/tape/engineering,
-/obj/item/tape/engineering,
-/obj/item/tape/engineering,
-/obj/item/tape/engineering,
-/obj/item/tape/engineering,
-/obj/item/tape/engineering,
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/engineering,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/breakroom)
 "cLN" = (
@@ -64105,7 +64097,6 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/hallway/main/section2)
 "cQU" = (
-/obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/oldtele)
@@ -69855,8 +69846,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/structure/sign/semiotic/coffee{
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/command/meeting_room)
@@ -69888,6 +69879,9 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/command/meeting_room)
@@ -75123,7 +75117,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/sign/semiotic/no_grav_no_press{
+/obj/structure/sign/semiotic/nonpressurised_suit{
 	pixel_x = -24;
 	pixel_y = 6
 	},
@@ -76392,12 +76386,12 @@
 /area/eris/maintenance/section3deck2starboard)
 "dss" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/table/standard,
 /obj/item/soap,
 /obj/item/bikehorn/rubberducky,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "dst" = (
@@ -77057,14 +77051,9 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbay)
 "dtS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/eris/neotheology/chapel)
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/eris/crew_quarters/fitness)
 "dtT" = (
 /obj/machinery/power/rad_collector,
 /turf/simulated/floor/tiled/steel/cargo,
@@ -78923,6 +78912,7 @@
 /area/eris/maintenance/oldbridge)
 "dyu" = (
 /obj/structure/closet/secure_closet/reinforced/CMO,
+/obj/item/taperoll/medical,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/command/mbo)
 "dyv" = (
@@ -80350,6 +80340,12 @@
 	name = "Holodeck Door"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/crew_quarters/fitness)
 "dBN" = (
@@ -87309,15 +87305,13 @@
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
 "dRh" = (
-/obj/structure/mopbucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
 /obj/machinery/button/remote/blast_door{
 	id = "maint_hatch_lower_cargo";
 	name = "Maintenance Hatch Control";
 	pixel_x = 24;
 	req_access = null
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/hangarsupply)
 "dRi" = (
@@ -87602,7 +87596,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/mopbucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/hangarsupply)
 "dRR" = (
@@ -92314,21 +92310,13 @@
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "ecR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/camera/network/third_section{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "ecS" = (
@@ -93477,9 +93465,6 @@
 /area/eris/quartermaster/misc)
 "efA" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -96442,8 +96427,10 @@
 /turf/simulated/open,
 /area/eris/maintenance/section4deck1central)
 "emk" = (
-/obj/machinery/vending/snack,
-/turf/simulated/wall/r_wall,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "eml" = (
 /turf/simulated/wall,
@@ -97353,10 +97340,7 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/misc)
 "eoA" = (
-/turf/simulated/floor/reinforced{
-	name = "engine floor";
-	oxygen = 0
-	},
+/turf/simulated/floor/reinforced,
 /area/eris/crew_quarters/fitness)
 "eoB" = (
 /obj/structure/table/standard,
@@ -98438,11 +98422,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck2starboard)
 "erg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/wall,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/tiled/steel,
+/area/eris/crew_quarters/fitness)
 "erh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -101619,9 +101603,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -104839,7 +104820,7 @@
 /obj/item/hatton_magazine,
 /obj/item/hatton_magazine,
 /obj/item/hatton_magazine,
-/obj/item/tape/engineering,
+/obj/item/taperoll/engineering,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/command/exultant)
 "eEH" = (
@@ -106046,8 +106027,10 @@
 /turf/simulated/floor/wood,
 /area/eris/command/bridgebar)
 "eSM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/steel,
@@ -106125,13 +106108,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
 "fbV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "fea" = (
@@ -106306,10 +106284,6 @@
 /area/space)
 "fRb" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/item/stool/padded,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
@@ -106422,11 +106396,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck1central)
 "geb" = (
-/obj/machinery/gym,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/brown_perforated,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
 "gga" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -106517,11 +106490,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/airlock,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "gBc" = (
@@ -106565,16 +106538,16 @@
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/medbay)
 "gPS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/wall,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
 "gTy" = (
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -106704,8 +106677,11 @@
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/checkpoint/science)
 "hmj" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
@@ -106806,9 +106782,8 @@
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/fitness)
@@ -107022,9 +106997,14 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/neotheology/chapelritualroom)
 "iKF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/bcarpet,
-/area/eris/neotheology/chapelritualroom)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/eris/crew_quarters/fitness)
 "iLh" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/steel/panels,
@@ -107238,8 +107218,9 @@
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/engineering/post)
 "juQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
@@ -107420,8 +107401,8 @@
 	pixel_y = -24
 	},
 /obj/structure/sign/semiotic/directions{
-	dir = 4;
-	pixel_x = 6;
+	dir = 8;
+	pixel_x = -6;
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -107480,12 +107461,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/range)
-"ktP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/eris/crew_quarters/fitness)
 "kvo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -107917,12 +107892,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
-"lPx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/steel,
-/area/eris/crew_quarters/fitness)
 "lRo" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/firealarm{
@@ -107954,9 +107923,8 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/command/bridge)
 "lRL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
 "lSz" = (
@@ -108303,13 +108271,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
-"mUB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/steel,
-/area/eris/crew_quarters/fitness)
 "mVe" = (
 /obj/machinery/door/airlock{
 	id_tag = "BridgeToilet1";
@@ -108408,10 +108369,7 @@
 /area/eris/quartermaster/hangarsupply)
 "nsi" = (
 /obj/machinery/gym/toughness,
-/turf/simulated/floor/reinforced{
-	name = "engine floor";
-	oxygen = 0
-	},
+/turf/simulated/floor/reinforced,
 /area/eris/crew_quarters/fitness)
 "ntp" = (
 /obj/machinery/hologram/holopad,
@@ -108571,7 +108529,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/item/target/syndicate,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
@@ -108782,10 +108739,7 @@
 /obj/item/tool/hammer/dumbbell{
 	pixel_y = 7
 	},
-/turf/simulated/floor/reinforced{
-	name = "engine floor";
-	oxygen = 0
-	},
+/turf/simulated/floor/reinforced,
 /area/eris/crew_quarters/fitness)
 "ovh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -109013,6 +108967,8 @@
 "pbu" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "pij" = (
@@ -109109,20 +109065,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
-"pGe" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/eris/crew_quarters/fitness)
-"pGN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/wall/r_wall,
-/area/eris/maintenance/section3deck1central)
 "pGT" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 1;
@@ -109194,14 +109136,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
-"pWC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/wood{
-	dir = 1
-	},
-/obj/landmark/join/start/hydro,
-/turf/simulated/floor/carpet/bcarpet,
-/area/eris/neotheology/chapelritualroom)
 "qaq" = (
 /obj/structure/toilet{
 	dir = 4
@@ -109354,6 +109288,7 @@
 	dir = 1;
 	pixel_y = -23
 	},
+/obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
 "qEt" = (
@@ -109451,6 +109386,9 @@
 /area/eris/quartermaster/storage)
 "qXB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
@@ -109671,6 +109609,9 @@
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
 "rNt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -109747,9 +109688,6 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/breakroom)
 "rZh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/structure/table/marble,
 /obj/item/book/ritual/cruciform,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -109907,12 +109845,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_female/toilet_female)
-"sBc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/eris/crew_quarters/fitness)
 "sBX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -109924,13 +109856,6 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
 	tag = "icon-danger (WEST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -110013,8 +109938,8 @@
 /turf/simulated/floor/reinforced,
 /area/eris/medical/chemstor)
 "sLu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/oldtele)
@@ -110133,13 +110058,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
-"tnB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/steel,
-/area/eris/crew_quarters/fitness)
 "toI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -110186,8 +110104,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck4central)
 "tCi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/oldtele)
@@ -110430,6 +110348,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/command/bridgetoilet)
 "uvC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/fitness)
 "uvI" = (
@@ -110724,6 +110645,9 @@
 	dir = 1;
 	pixel_y = 26
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/fitness)
 "vta" = (
@@ -110765,9 +110689,6 @@
 /turf/simulated/wall/r_wall,
 /area/eris/crew_quarters/sleep_male/toilet_male)
 "vBm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
@@ -110932,12 +110853,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
-"wgR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/wall,
-/area/eris/crew_quarters/fitness)
 "wja" = (
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/wall/r_wall,
@@ -110954,6 +110869,9 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/eris/engineering/engine_room)
 "wkU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -110987,8 +110905,11 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
 "wns" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
@@ -111094,10 +111015,7 @@
 /area/eris/engineering/long_range_scanner)
 "wNc" = (
 /obj/machinery/gym/robustness,
-/turf/simulated/floor/reinforced{
-	name = "engine floor";
-	oxygen = 0
-	},
+/turf/simulated/floor/reinforced,
 /area/eris/crew_quarters/fitness)
 "wOW" = (
 /obj/structure/closet/secure_closet/medicine,
@@ -111126,15 +111044,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/hallway/side/bridgehallway)
-"wWI" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/crew_quarters/fitness)
 "wXf" = (
 /obj/structure/closet/secure_closet/medicine,
 /obj/machinery/light/small{
@@ -124307,7 +124216,7 @@ ayC
 azl
 avN
 ccJ
-cem
+ceU
 ceU
 avN
 aaa
@@ -124508,9 +124417,9 @@ axu
 ayy
 azj
 avN
-bZP
-avK
-bkn
+btZ
+ceU
+ceU
 avN
 aaa
 aaa
@@ -136618,7 +136527,7 @@ aaa
 aaa
 aaa
 avn
-awG
+ata
 cgl
 auV
 btk
@@ -165711,8 +165620,8 @@ byR
 bXY
 bXY
 rZh
-iKF
-pWC
+bXY
+sAr
 sAr
 bXY
 bGD
@@ -173365,7 +173274,7 @@ aEO
 bfn
 aHX
 apJ
-hhc
+cDN
 hhc
 uEj
 apJ
@@ -246716,7 +246625,7 @@ eaj
 awr
 cDi
 vtO
-dtS
+cmE
 mvF
 ebW
 ebW
@@ -247925,7 +247834,7 @@ abF
 abF
 awr
 cKw
-cDM
+dtS
 awr
 nsi
 eoA
@@ -248134,7 +248043,7 @@ eoA
 ydA
 cDu
 vrq
-uvC
+kvo
 cDu
 onI
 cDM
@@ -248333,7 +248242,7 @@ cDM
 dxq
 ouQ
 eoA
-cDM
+cJR
 cDu
 hmj
 dss
@@ -248538,7 +248447,7 @@ eoA
 qCl
 cDu
 gzK
-ata
+cDu
 cDu
 onI
 cDM
@@ -248737,10 +248646,10 @@ cDM
 dxq
 ouQ
 eoA
-cJR
-cDi
-ktP
-pGe
+cDM
+emk
+qXB
+oyg
 cDu
 rnm
 cDM
@@ -248939,9 +248848,9 @@ cDM
 dxq
 wNc
 eoA
-cDN
-cDi
-mUB
+cDM
+erg
+qXB
 fRb
 cDu
 onI
@@ -249142,7 +249051,7 @@ dxq
 ouQ
 eoA
 cDM
-cDM
+geb
 wkU
 vBm
 cDu
@@ -249344,8 +249253,8 @@ dxq
 ouQ
 eoA
 cDM
-cDM
-wkU
+gPS
+iKF
 lRL
 wns
 pbu
@@ -249547,10 +249456,10 @@ wNc
 eoA
 oRV
 uvC
-geb
+oRV
 awt
 rNt
-wgR
+cDu
 hNQ
 gzs
 awr
@@ -249749,11 +249658,11 @@ awr
 dxq
 dxq
 bhE
-cDL
+dxq
 cDL
 dBM
-gPS
-sBc
+cDu
+cDu
 awr
 awr
 dHk
@@ -249951,11 +249860,11 @@ cEy
 cEy
 cDi
 cDi
-lPx
-tnB
+cDi
+cDi
 qXB
-ktP
-wWI
+cDi
+cEy
 euq
 ovX
 cDi
@@ -250154,7 +250063,7 @@ ebV
 cDi
 cDi
 cDi
-lPx
+cDi
 eSM
 fbV
 ecR
@@ -250550,7 +250459,7 @@ dqI
 dqI
 enV
 awr
-emk
+awr
 exz
 eas
 cFK
@@ -288133,7 +288042,7 @@ eqI
 boS
 boS
 bsI
-erg
+boS
 boS
 elC
 boS
@@ -288335,7 +288244,7 @@ cNH
 cNH
 ebc
 vfA
-btZ
+dXi
 dXi
 bkF
 boS
@@ -288537,7 +288446,7 @@ cxK
 cxK
 cxK
 nSC
-btZ
+dXi
 dXi
 bkF
 boS
@@ -288739,7 +288648,7 @@ mZv
 mZv
 mZv
 fly
-btZ
+dXi
 dXi
 bkF
 boS
@@ -288941,7 +288850,7 @@ oCA
 cNH
 slc
 vfA
-btZ
+dXi
 cNH
 bkF
 boS
@@ -289143,7 +289052,7 @@ jir
 boS
 boS
 bsI
-btZ
+dXi
 cNH
 bkF
 boS
@@ -289345,7 +289254,7 @@ oCA
 cNH
 ebc
 vfA
-btZ
+dXi
 cNH
 bkF
 boS
@@ -289547,7 +289456,7 @@ lSz
 lSz
 lSz
 sBX
-btZ
+dXi
 dXi
 bkF
 boN
@@ -289749,7 +289658,7 @@ cIg
 cIg
 cIg
 lDx
-pGN
+dXi
 dXi
 bkF
 boN
@@ -289951,7 +289860,7 @@ cNH
 cNH
 slc
 vfA
-btZ
+dXi
 dXi
 bkF
 boS
@@ -290153,7 +290062,7 @@ eqI
 boS
 boS
 bsI
-erg
+boS
 boS
 elC
 boS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Replaces engine-room reinforced floor tiles in Fitness Room with standard variety. The engine-room variant is hardcoded to spawn sans oxygen, for reasons that hopefully should be obvious.
- Completely redid the Fitness Room's atmospherics network. Duplicate pipes were removed, entry points of pipes into rooms were moved into doorways for consistency.
- Major tweaks to the atmospherics network in the firing range, for much the same reasons.
- Tweaked the Church's Cahors barrel storage room, due to Cahors barrels ripping up pipes
- Tweaked Hydroponics and the mop closet in Cargonia, due to the large water tanks ripping up pipes.
- Fixed some erroneous semiotic-standard signage.

## Why It's Good For The Game

- Fitness room now starts pressurised. 
- The atmospherics networks in the Fitness Room and the firing range now function properly and can be ran on foot.
  - The firing range still needs to be brought up to the standards of the other atmospherics networks on the ship, but that's a project for another time.
- Pipes are no longer getting ripped up by the large reagent tanks.
- Semiotic standard signage is now actually correct (and, in one case, not two signs overlaid on top of one another).

## Testing

### Fitness room pressure testing
![image](https://github.com/user-attachments/assets/6d25ff64-45ab-4c94-b304-43fd3e6f34bd)

### Atmospherics network fixes
Pipenet check
![image](https://github.com/user-attachments/assets/2e7ca8d0-46b1-4e53-96e7-97c1ae6c8d67)

Firing range
![image](https://github.com/user-attachments/assets/a25671ca-f25a-456d-b520-344c4cb560c5)

Fitness room
![image](https://github.com/user-attachments/assets/56f90f8c-3af3-44be-8957-acab6e3782cd)

### Fixed semiotic signage
Bridge hallway (was overlaid on each other)
![image](https://github.com/user-attachments/assets/6c2241c7-f929-49f8-af45-7d803c1b21ef)

JTB (erroneously stated gravity was absent)
![image](https://github.com/user-attachments/assets/94cc0ccb-1b49-4a75-adaf-23a9777bf8bc)


## Changelog
:cl:
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
