### PR TITLE
Map Fixes

### DIFF
--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -2261,6 +2261,7 @@
 "afv" = (
 /obj/structure/closet/secure_closet/reinforced/hos,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/taperoll/police,
 /turf/simulated/floor/wood,
 /area/eris/command/commander)
 "afw" = (
@@ -8519,14 +8520,21 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
 "ata" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/camera/network/third_section,
+/obj/structure/sign/semiotic/bulkhead{
+	pixel_x = -8;
+	pixel_y = 24
 	},
-/turf/simulated/wall,
-/area/eris/crew_quarters/fitness)
+/obj/structure/sign/semiotic/directions{
+	dir = 4;
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/eris/hallway/side/section3starboard)
 "atb" = (
 /turf/simulated/wall,
 /area/eris/maintenance/fueltankstorage)
@@ -9535,13 +9543,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/hallway/side/section3starboard)
-"avK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/wood,
-/area/eris/neotheology/storage)
 "avL" = (
 /obj/structure/railing{
 	dir = 1;
@@ -9793,9 +9794,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/armory)
 "awt" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/fitness)
 "awu" = (
@@ -9838,6 +9836,10 @@
 /area/eris/maintenance/section2deck4port)
 "awA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/eschangara)
 "awB" = (
@@ -10012,7 +10014,7 @@
 "awY" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	sortType = list("QM    Office");
+	sortType = list("QM        Office");
 	tag = "icon-pipe-j2s"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -20901,6 +20903,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/taperoll/police,
+/obj/item/taperoll/police,
+/obj/item/taperoll/police,
+/obj/item/taperoll/police,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/security/barracks)
 "aXo" = (
@@ -23300,6 +23306,7 @@
 /obj/item/tank/emergency_oxygen/double,
 /obj/item/tank/emergency_oxygen/double,
 /obj/machinery/light/small,
+/obj/item/taperoll/atmos,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/engineering/atmos/storage)
 "bce" = (
@@ -23469,7 +23476,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
 	icon_state = "pipe-j2s";
-	sortType = list("Security","First    Officer    Office")
+	sortType = list("Security","First        Officer        Office")
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -23986,9 +23993,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "bdc" = (
@@ -24210,7 +24214,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	sortType = list("Medbay","CMO    Office","Chemistry","Research","Robotics");
+	sortType = list("Medbay","CMO        Office","Chemistry","Research","Robotics");
 	tag = "icon-pipe-j2s"
 	},
 /obj/structure/cable/green{
@@ -25906,6 +25910,17 @@
 /obj/machinery/camera/network/third_section{
 	dir = 4
 	},
+/obj/structure/table/rack,
+/obj/item/gun/energy/laser/paladin,
+/obj/item/gun/energy/laser/paladin,
+/obj/item/cell/medium/neotheology,
+/obj/item/cell/medium/neotheology,
+/obj/item/cell/medium/neotheology,
+/obj/item/cell/medium/neotheology,
+/obj/item/cell/medium/neotheology,
+/obj/item/cell/medium/neotheology,
+/obj/item/clothing/head/powdered_wig,
+/obj/item/clothing/head/powdered_wig,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/storage)
 "bhD" = (
@@ -27119,6 +27134,17 @@
 	dir = 4;
 	pixel_x = -26
 	},
+/obj/structure/table/rack,
+/obj/item/gun/energy/laser/paladin,
+/obj/item/gun/energy/laser/paladin,
+/obj/item/cell/medium/neotheology,
+/obj/item/cell/medium/neotheology,
+/obj/item/cell/medium/neotheology,
+/obj/item/cell/medium/neotheology,
+/obj/item/cell/medium/neotheology,
+/obj/item/cell/medium/neotheology,
+/obj/item/clothing/head/powdered_wig,
+/obj/item/clothing/head/powdered_wig,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/storage)
 "bke" = (
@@ -27208,13 +27234,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section2)
-"bkn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/turf/simulated/floor/wood,
-/area/eris/neotheology/storage)
 "bko" = (
 /obj/structure/table/standard,
 /obj/item/reagent_containers/spray/cleaner,
@@ -28424,16 +28443,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/lab)
 "bmS" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "bmT" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -28645,7 +28657,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	sortType = list("RD    Office");
+	sortType = list("RD        Office");
 	tag = "icon-pipe-j2s"
 	},
 /obj/structure/catwalk,
@@ -29759,7 +29771,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	sortType = list("NeoTheology    Machine    Room");
+	sortType = list("NeoTheology        Machine        Room");
 	tag = "icon-pipe-j2s"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -29827,16 +29839,12 @@
 	dir = 4
 	},
 /obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel/techfloor_grid)
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/quartermaster/storage)
 "bqa" = (
 /obj/structure/table/standard,
 /obj/item/device/lighting/toggleable/lamp,
@@ -30814,8 +30822,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/wall,
-/area/eris/maintenance/section3deck1central)
+/obj/structure/railing{
+	dir = 8;
+	tag = "icon-railing0 (WEST)"
+	},
+/turf/simulated/floor/plating/under,
+/area/erida/crew_quarters/firing_range)
 "bsJ" = (
 /obj/landmark/join/observer,
 /turf/simulated/floor/tiled/steel,
@@ -31418,11 +31430,11 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/medical/virology)
 "btZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/wall/r_wall,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/wood,
+/area/eris/neotheology/storage)
 "bua" = (
 /obj/structure/bed/chair/office/dark,
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -31856,7 +31868,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("mair_in_meter"="Mixed    Air    In","air_sensor"="Mixed    Air    Supply    Tank","mair_out_meter"="Mixed    Air    Out","dloop_atm_meter"="Distribution    Loop","wloop_atm_meter"="Waste    Loop")
+	sensors = list("mair_in_meter"="Mixed        Air        In","air_sensor"="Mixed        Air        Supply        Tank","mair_out_meter"="Mixed        Air        Out","dloop_atm_meter"="Distribution        Loop","wloop_atm_meter"="Waste        Loop")
 	},
 /obj/machinery/camera/network/engineering{
 	dir = 1
@@ -32186,10 +32198,12 @@
 /area/eris/maintenance/section3deck1central)
 "bvP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/wood,
 /area/eris/neotheology/storage)
@@ -33116,7 +33130,7 @@
 	dir = 8;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon    Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous    Oxide","waste_sensor"="Gas    Mix    Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon        Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous        Oxide","waste_sensor"="Gas        Mix        Tank")
 	},
 /obj/machinery/power/apc{
 	name = "South APC";
@@ -33907,10 +33921,6 @@
 /area/eris/rnd/scient)
 "bzI" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_mining{
-	name = "Artist's office";
-	req_access = list(44)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -33922,7 +33932,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel/cargo)
+/obj/machinery/door/airlock/glass_mining{
+	name = "Cargo Bay";
+	req_access = list(50)
+	},
+/turf/simulated/floor/tiled/steel/cargo,
+/area/eris/quartermaster/storage)
 "bzJ" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "engeve_access_console";
@@ -34009,7 +34024,8 @@
 	name = "Cargo Total Lockdown";
 	opacity = 0
 	},
-/turf/simulated/floor/plating)
+/turf/simulated/floor/plating,
+/area/eris/quartermaster/storage)
 "bzO" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -38733,6 +38749,7 @@
 /area/eris/security/inspectors_office)
 "bKm" = (
 /obj/structure/closet/secure_closet/detective,
+/obj/item/taperoll/police,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/inspectors_office)
 "bKn" = (
@@ -38982,7 +38999,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
 	icon_state = "pipe-j2s";
-	sortType = list("Engineering","CE    Office","Atmospherics")
+	sortType = list("Engineering","CE        Office","Atmospherics")
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -40053,7 +40070,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/sortjunction{
-	sortType = list("Construction    Site")
+	sortType = list("Construction        Site")
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -40669,10 +40686,7 @@
 	pixel_y = 7
 	},
 /obj/structure/table/rack,
-/turf/simulated/floor/reinforced{
-	name = "engine floor";
-	oxygen = 0
-	},
+/turf/simulated/floor/reinforced,
 /area/eris/crew_quarters/fitness)
 "bOj" = (
 /turf/simulated/floor/plating,
@@ -43672,7 +43686,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	sortType = list("First    Officer    Office")
+	sortType = list("First        Officer        Office")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -43787,11 +43801,11 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/maintenance/section1deck3central)
 "bVr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/machinery/camera/network/third_section{
 	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/eris/neotheology/storage)
@@ -45897,9 +45911,6 @@
 /area/eris/maintenance/section3deck4starboard)
 "can" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_y = 8
@@ -47599,13 +47610,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
-"cem" = (
-/obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/eris/neotheology/storage)
 "cen" = (
 /obj/item/modular_computer/console/preset/genetics,
 /turf/simulated/floor/tiled/white,
@@ -47961,9 +47965,6 @@
 /area/eris/rnd/mixing)
 "ceU" = (
 /obj/structure/reagent_dispensers/cahorsbarrel,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/simulated/floor/wood,
 /area/eris/neotheology/storage)
 "ceV" = (
@@ -48819,13 +48820,10 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section2)
 "cgQ" = (
-/obj/item/contraband/poster/placed{
-	icon_state = "poster6";
-	pixel_x = -32;
-	tag = "icon-poster6"
-	},
-/obj/structure/flora/pottedplant/random,
-/turf/simulated/floor/carpet/gaycarpet)
+/obj/structure/table/rack/shelf,
+/obj/spawner/pack/tech_loot,
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "cgR" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/steel,
@@ -48892,7 +48890,8 @@
 /turf/simulated/floor/wood,
 /area/eris/command/fo)
 "chd" = (
-/turf/simulated/floor/tiled/steel/techfloor_grid)
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/quartermaster/storage)
 "che" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -48905,7 +48904,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/steel/techfloor_grid)
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/quartermaster/storage)
 "chf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -48928,7 +48928,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel/techfloor_grid)
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/quartermaster/storage)
 "chi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -49048,7 +49049,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/obj/structure/table/rack/shelf,
+/obj/spawner/material/resources,
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "chv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -49072,7 +49076,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "chy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
@@ -49184,19 +49189,22 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/obj/structure/table/rack/shelf,
+/obj/spawner/material/resources,
+/obj/spawner/material/resources,
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "chI" = (
-/obj/structure/bed/chair/office/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/landmark/join/start/artist,
-/turf/simulated/floor/carpet/gaycarpet)
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "chJ" = (
-/obj/item/modular_computer/console/preset/civilian/professional{
-	dir = 8
-	},
-/turf/simulated/floor/carpet/gaycarpet)
+/obj/structure/table/rack/shelf,
+/obj/spawner/material/building,
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "chK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -49249,13 +49257,10 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "chT" = (
-/obj/structure/table/rack,
-/obj/item/device/synthesized_instrument/violin,
-/obj/item/device/synthesized_instrument/trumpet,
-/obj/item/device/synthesized_instrument/guitar/multi,
-/obj/item/device/synthesized_instrument/guitar,
-/obj/item/device/synthesized_instrument/synthesizer,
-/turf/simulated/floor/carpet/gaycarpet)
+/obj/structure/table/rack/shelf,
+/obj/spawner/material/resources,
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "chU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -49274,12 +49279,16 @@
 /area/eris/crew_quarters/janitor)
 "chV" = (
 /obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen/blue{
-	pixel_x = -3;
-	pixel_y = 2
+/obj/machinery/recharger,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/gaycarpet)
+/obj/item/stack/material/wood/random,
+/obj/item/stack/material/steel/random,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "chW" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -49310,9 +49319,17 @@
 /turf/simulated/wall/r_wall,
 /area/eris/hallway/main/section3)
 "chZ" = (
-/obj/structure/table/standard,
-/obj/item/device/lighting/toggleable/lamp,
-/turf/simulated/floor/carpet/gaycarpet)
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "cia" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
@@ -49699,15 +49716,21 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/bar)
 "cjd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-y";
+	tag = "icon-pipe-y (EAST)"
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
@@ -49841,7 +49864,7 @@
 	input_tag = "toxins1_in";
 	name = "Mixing Chamber 1 Monitor";
 	output_tag = "toxins1_out";
-	sensors = list("toxins_mixing_1"="Mixing    Chamber    -    1")
+	sensors = list("toxins_mixing_1"="Mixing        Chamber        -        1")
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
@@ -49993,7 +50016,7 @@
 	dir = 8;
 	frequency = 1430;
 	name = "Mixing Chamber Monitor";
-	sensors = list("toxins_mixing_1"="Mixing    Chamber    -    1","toxins_mixing_2"="Mixing    Chamber    -    2")
+	sensors = list("toxins_mixing_1"="Mixing        Chamber        -        1","toxins_mixing_2"="Mixing        Chamber        -        2")
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/rnd/mixing)
@@ -50257,7 +50280,7 @@
 	input_tag = "toxins2_in";
 	name = "Mixing Chamber 2 Monitor";
 	output_tag = "toxins2_out";
-	sensors = list("toxins_mixing_2"="Mixing    Chamber    -    2")
+	sensors = list("toxins_mixing_2"="Mixing        Chamber        -        2")
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
@@ -50381,6 +50404,11 @@
 	dir = 4
 	},
 /obj/structure/cyberplant,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
 "ckK" = (
@@ -50401,6 +50429,11 @@
 	layer = 3.3;
 	name = "Maintenance Hatch"
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/bar)
 "ckL" = (
@@ -50416,6 +50449,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck4central)
@@ -50467,6 +50505,11 @@
 	dir = 1;
 	icon_state = "pipe-j2";
 	tag = "icon-pipe-j2 (NORTH)"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -50579,6 +50622,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
 "clg" = (
@@ -50662,6 +50710,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -51829,7 +51882,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/obj/structure/reagent_dispensers/watertank/huge,
+/obj/structure/closet/crate/secure/hydrosec/prelocked,
+/obj/item/reagent_containers/glass/bottle/mutagen,
+/obj/item/reagent_containers/dropper,
+/obj/item/tool/wrench,
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
 "cnZ" = (
@@ -53414,8 +53470,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/autolathe/artist_bench,
-/turf/simulated/floor/carpet/gaycarpet)
+/obj/structure/table/rack/shelf,
+/obj/spawner/material/building,
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "crB" = (
 /obj/structure/sign/department/dock{
 	pixel_y = 32
@@ -53899,7 +53957,7 @@
 /area/eris/crew_quarters/hydroponics)
 "csD" = (
 /turf/simulated/wall,
-/area/eris/maintenance/section3deck4port)
+/area/eris/crew_quarters/artistoffice)
 "csE" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -54040,8 +54098,10 @@
 /area/eris/neotheology/chapel)
 "ctb" = (
 /obj/machinery/camera/network/third_section,
-/obj/structure/closet/secure_closet/personal/artist,
-/turf/simulated/floor/carpet/gaycarpet)
+/obj/structure/table/rack/shelf,
+/obj/spawner/pack/tech_loot,
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "ctc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -54150,22 +54210,18 @@
 /obj/machinery/alarm{
 	pixel_y = 26
 	},
-/obj/structure/closet/wardrobe/color/pink/artist,
-/turf/simulated/floor/carpet/gaycarpet)
-"ctq" = (
 /obj/structure/table/rack/shelf,
+/obj/spawner/lowkeyrandom,
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
+"ctq" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/item/clothing/under/soviet,
-/obj/item/clothing/head/ushanka,
-/obj/item/clothing/suit/monkeysuit,
-/obj/item/clothing/mask/gas/monkeymask,
-/turf/simulated/floor/carpet/gaycarpet)
+/obj/structure/table/rack/shelf,
+/obj/spawner/lowkeyrandom,
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "ctr" = (
 /turf/simulated/wall/r_wall,
 /area/eris/quartermaster/office)
@@ -54404,7 +54460,8 @@
 	pixel_x = -24;
 	req_access = null
 	},
-/turf/simulated/floor/tiled/steel/techfloor_grid)
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/quartermaster/storage)
 "ctY" = (
 /obj/structure/lattice,
 /obj/structure/railing,
@@ -54903,6 +54960,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/taperoll/research,
 /turf/simulated/floor/carpet/purcarpet,
 /area/eris/command/meo)
 "cvj" = (
@@ -55825,10 +55883,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/item/reagent_containers/glass/bottle/mutagen,
-/obj/item/reagent_containers/dropper,
-/obj/structure/closet/crate/secure/hydrosec/prelocked,
-/obj/item/tool/wrench,
+/obj/structure/reagent_dispensers/watertank/huge,
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
 "cxl" = (
@@ -55910,7 +55965,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/turf/simulated/floor/tiled/steel/techfloor_grid)
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/quartermaster/storage)
 "cxu" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
@@ -56029,12 +56085,21 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cxK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
 	tag = "icon-danger (WEST)"
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "cxL" = (
 /obj/spawner/material/building,
 /obj/spawner/material/building,
@@ -56413,7 +56478,6 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/engineering/engine_room)
 "cyC" = (
-/obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/oldtele)
@@ -58778,9 +58842,15 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
 "cDN" = (
-/obj/machinery/vending/snack,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/eris/crew_quarters/fitness)
+/obj/structure/multiz/stairs/enter{
+	dir = 8
+	},
+/obj/structure/sign/directions/evac{
+	dir = 8;
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel,
+/area/eris/hallway/side/eschangarb)
 "cDO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating/under,
@@ -59552,7 +59622,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
 	icon_state = "pipe-j2s";
-	sortType = list("Cargo    Bay","QM    Office","Library    Backroom","Chapel","Preacher    Office","Theatre","Hydroponics","NeoTheology    Machine    Room");
+	sortType = list("Cargo        Bay","QM        Office","Library        Backroom","Chapel","Preacher        Office","Theatre","Hydroponics","NeoTheology        Machine        Room");
 	tag = "icon-pipe-j2s"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -60587,12 +60657,8 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/crew_quarters/janitor)
 "cIg" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4;
-	tag = "icon-danger (EAST)"
-	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "cIh" = (
 /obj/item/modular_computer/console/preset/engineering/power,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -62021,16 +62087,15 @@
 /obj/structure/table/standard,
 /obj/spawner/pack/tech_loot,
 /obj/spawner/pack/tech_loot,
-/obj/item/tape/engineering,
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
-/obj/item/tape/engineering,
-/obj/item/tape/engineering,
-/obj/item/tape/engineering,
-/obj/item/tape/engineering,
-/obj/item/tape/engineering,
-/obj/item/tape/engineering,
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/engineering,
+/obj/item/taperoll/engineering,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/breakroom)
 "cLN" = (
@@ -64046,12 +64111,15 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
 "cQM" = (
-/obj/structure/railing{
-	dir = 8;
-	tag = "icon-railing0 (WEST)"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/open,
-/area/eris/maintenance/section3deck4port)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "cQN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
 /obj/machinery/meter,
@@ -64105,7 +64173,6 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/hallway/main/section2)
 "cQU" = (
-/obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/oldtele)
@@ -68530,7 +68597,7 @@
 	req_access = list(12)
 	},
 /turf/simulated/floor/tiled/techmaint_cargo,
-/area/eris/maintenance/section3deck4port)
+/area/eris/crew_quarters/artistoffice)
 "dbq" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -69855,8 +69922,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/structure/sign/semiotic/coffee{
+	pixel_x = -24
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/command/meeting_room)
@@ -69888,6 +69955,9 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
 	},
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/command/meeting_room)
@@ -70813,7 +70883,7 @@
 /area/eris/rnd/xenobiology)
 "dgs" = (
 /turf/simulated/floor/tiled/dark/panels,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "dgt" = (
 /turf/simulated/wall/r_wall,
 /area/eris/command/fo/quarters)
@@ -75123,7 +75193,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/sign/semiotic/no_grav_no_press{
+/obj/structure/sign/semiotic/nonpressurised_suit{
 	pixel_x = -24;
 	pixel_y = 6
 	},
@@ -76392,12 +76462,12 @@
 /area/eris/maintenance/section3deck2starboard)
 "dss" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
 /obj/structure/table/standard,
 /obj/item/soap,
 /obj/item/bikehorn/rubberducky,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "dst" = (
@@ -77057,14 +77127,9 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbay)
 "dtS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall/r_wall,
-/area/eris/neotheology/chapel)
+/obj/machinery/vending/snack,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/eris/crew_quarters/fitness)
 "dtT" = (
 /obj/machinery/power/rad_collector,
 /turf/simulated/floor/tiled/steel/cargo,
@@ -78923,6 +78988,7 @@
 /area/eris/maintenance/oldbridge)
 "dyu" = (
 /obj/structure/closet/secure_closet/reinforced/CMO,
+/obj/item/taperoll/medical,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/command/mbo)
 "dyv" = (
@@ -80350,6 +80416,12 @@
 	name = "Holodeck Door"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/crew_quarters/fitness)
 "dBN" = (
@@ -80684,7 +80756,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	sortType = list("CMO    Office")
+	sortType = list("CMO        Office")
 	},
 /obj/structure/bed/chair/office/light{
 	dir = 1
@@ -82459,7 +82531,7 @@
 "dGD" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	sortType = list("Cargo    Bay");
+	sortType = list("Cargo        Bay");
 	tag = "icon-pipe-j2s"
 	},
 /turf/simulated/floor/plating/under,
@@ -83870,7 +83942,7 @@
 	dir = 1;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon    Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous    Oxide","waste_sensor"="Gas    Mix    Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon        Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous        Oxide","waste_sensor"="Gas        Mix        Tank")
 	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/command/exultant)
@@ -84746,7 +84818,7 @@
 	input_tag = "cooling_in";
 	name = "Engine Cooling Control";
 	output_tag = "cooling_out";
-	sensors = list("engine_sensor"="Engine    Core")
+	sensors = list("engine_sensor"="Engine        Core")
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/engine_room)
@@ -87309,15 +87381,13 @@
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
 "dRh" = (
-/obj/structure/mopbucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
 /obj/machinery/button/remote/blast_door{
 	id = "maint_hatch_lower_cargo";
 	name = "Maintenance Hatch Control";
 	pixel_x = 24;
 	req_access = null
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/hangarsupply)
 "dRi" = (
@@ -87602,7 +87672,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/mopbucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/mop,
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/hangarsupply)
 "dRR" = (
@@ -91609,11 +91681,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/anomalisoltwo)
 "ebc" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/wall,
+/area/erida/crew_quarters/firing_range)
 "ebd" = (
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/misc_lab)
@@ -92314,21 +92383,13 @@
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "ecR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/machinery/camera/network/third_section{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "ecS" = (
@@ -93477,9 +93538,6 @@
 /area/eris/quartermaster/misc)
 "efA" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -94417,12 +94475,11 @@
 /area/eris/maintenance/section4deck1central)
 "ehJ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Theatre";
-	req_access = newlist()
+/obj/machinery/door/airlock/security{
+	name = "Shooting Range"
 	},
-/turf/simulated/floor/wood,
-/area/eris/crew_quarters/clownoffice)
+/turf/simulated/floor/tiled/steel/cargo,
+/area/erida/crew_quarters/firing_range)
 "ehK" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -94634,7 +94691,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
 	icon_state = "pipe-j2s";
-	sortType = list("CE    Office")
+	sortType = list("CE        Office")
 	},
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -95381,8 +95438,7 @@
 "ejK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_interior{
-	name = "Theatre Maintenance";
-	req_access = list(43)
+	name = "Shooting Range Maintenance"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -95390,11 +95446,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techmaint_cargo,
-/area/eris/crew_quarters/clownoffice)
+/area/erida/crew_quarters/firing_range)
 "ejL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -96442,8 +96495,10 @@
 /turf/simulated/open,
 /area/eris/maintenance/section4deck1central)
 "emk" = (
-/obj/machinery/vending/snack,
-/turf/simulated/wall/r_wall,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "eml" = (
 /turf/simulated/wall,
@@ -96586,7 +96641,7 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/eris/crew_quarters/clownoffice)
+/area/erida/crew_quarters/firing_range)
 "emH" = (
 /obj/structure/plasticflaps/mining,
 /turf/simulated/floor/plating/under,
@@ -97011,17 +97066,16 @@
 /area/eris/rnd/research)
 "enL" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_interior{
-	name = "Theatre Maintenance";
-	req_access = list(43)
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/airlock/glass_security{
+	name = "Shooting Range"
+	},
 /turf/simulated/floor/tiled/techmaint_cargo,
-/area/eris/crew_quarters/clownoffice)
+/area/erida/crew_quarters/firing_range)
 "enM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
@@ -97101,8 +97155,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint_cargo,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "enV" = (
 /obj/structure/multiz/ladder/up,
 /turf/simulated/floor/tiled/techmaint,
@@ -97353,10 +97410,7 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/misc)
 "eoA" = (
-/turf/simulated/floor/reinforced{
-	name = "engine floor";
-	oxygen = 0
-	},
+/turf/simulated/floor/reinforced,
 /area/eris/crew_quarters/fitness)
 "eoB" = (
 /obj/structure/table/standard,
@@ -98180,10 +98234,8 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/library)
 "eqI" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/wall/r_wall,
+/area/erida/crew_quarters/firing_range)
 "eqJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -98438,11 +98490,11 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck2starboard)
 "erg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/wall,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/tiled/steel,
+/area/eris/crew_quarters/fitness)
 "erh" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -98477,13 +98529,13 @@
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/eris/crew_quarters/clownoffice)
+/area/erida/crew_quarters/firing_range)
 "erm" = (
 /obj/structure/multiz/stairs/active{
 	dir = 4
 	},
 /turf/simulated/floor/wood,
-/area/eris/crew_quarters/clownoffice)
+/area/erida/crew_quarters/firing_range)
 "ern" = (
 /obj/structure/sign/department/morgue{
 	pixel_x = -32
@@ -98496,7 +98548,12 @@
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/surgery)
 "ero" = (
-/turf/simulated/wall)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4;
+	tag = "icon-danger (EAST)"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "erp" = (
 /obj/machinery/light,
 /obj/structure/closet/coffin,
@@ -98568,13 +98625,14 @@
 /area/eris/maintenance/section3deck1central)
 "erw" = (
 /obj/structure/table/rack,
-/turf/simulated/floor/wood,
-/area/eris/crew_quarters/clownoffice)
+/obj/item/gun/energy/laser/practice,
+/obj/item/cell/medium/high,
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "erx" = (
 /obj/machinery/camera/network/third_section,
-/obj/structure/table/rack,
-/turf/simulated/floor/wood,
-/area/eris/crew_quarters/clownoffice)
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "ery" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -98591,8 +98649,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/clownoffice)
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "erA" = (
 /obj/structure/table/standard,
 /obj/spawner/pack/tech_loot/low_chance,
@@ -98608,9 +98666,8 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
 "erC" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/wood,
-/area/eris/crew_quarters/clownoffice)
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "erD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -98631,31 +98688,35 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/clownoffice)
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "erG" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/clownoffice)
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "erH" = (
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/clownoffice)
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "erI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/clownoffice)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "erJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -98674,11 +98735,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/eris/crew_quarters/clownoffice)
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "erL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_engineering{
@@ -98800,14 +98858,16 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/engineering/breakroom)
 "erX" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "erY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -98825,6 +98885,9 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck1central)
@@ -99636,11 +99699,10 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/misc)
 "etL" = (
-/obj/machinery/door/airlock{
-	name = "Theatre";
-	req_access = newlist()
+/obj/machinery/door/airlock/security{
+	name = "Shooting Range"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/crew_quarters/fitness)
 "etM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -100883,10 +100945,6 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
 "ewp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
@@ -101129,16 +101187,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
 "ewQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/window_lwall_spawn/smartspawn,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/modular_computer/console/preset/civilian/professional,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "ewR" = (
 /obj/structure/table/standard,
 /obj/item/clothing/mask/breath,
@@ -101331,7 +101385,7 @@
 /area/eris/storage/primary)
 "exl" = (
 /obj/machinery/camera/network/third_section,
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/crew_quarters/fitness)
 "exm" = (
 /obj/machinery/firealarm{
@@ -101380,7 +101434,6 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/misc)
 "exs" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -101391,11 +101444,13 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "ext" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/railing{
 	dir = 8;
 	tag = "icon-railing0 (WEST)"
@@ -101405,6 +101460,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -101619,9 +101678,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
@@ -102215,8 +102271,8 @@
 /area/eris/maintenance/section2deck1port)
 "ezg" = (
 /obj/machinery/camera/network/third_section,
-/turf/simulated/floor/wood,
-/area/eris/crew_quarters/clownoffice)
+/turf/simulated/floor/tiled/steel/cargo,
+/area/erida/crew_quarters/firing_range)
 "ezh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/disposalpipe/segment,
@@ -102279,20 +102335,18 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "ezm" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/clownoffice)
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "ezn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/device/radio/intercom{
 	pixel_y = 24
 	},
-/turf/simulated/floor/wood,
-/area/eris/crew_quarters/clownoffice)
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "ezo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -102316,15 +102370,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -23
 	},
-/turf/simulated/floor/wood,
-/area/eris/crew_quarters/clownoffice)
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "ezr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
@@ -102446,7 +102497,7 @@
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
 	icon_state = "pipe-j2s";
-	sortType = list("Library    Backroom")
+	sortType = list("Library        Backroom")
 	},
 /obj/structure/railing{
 	dir = 4;
@@ -104839,7 +104890,7 @@
 /obj/item/hatton_magazine,
 /obj/item/hatton_magazine,
 /obj/item/hatton_magazine,
-/obj/item/tape/engineering,
+/obj/item/taperoll/engineering,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/command/exultant)
 "eEH" = (
@@ -105419,7 +105470,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("mair_in_meter"="Mixed    Air    In","air_sensor"="Mixed    Air    Supply    Tank","mair_out_meter"="Mixed    Air    Out","dloop_atm_meter"="Distribution    Loop","wloop_atm_meter"="Engine    Waste")
+	sensors = list("mair_in_meter"="Mixed        Air        In","air_sensor"="Mixed        Air        Supply        Tank","mair_out_meter"="Mixed        Air        Out","dloop_atm_meter"="Distribution        Loop","wloop_atm_meter"="Engine        Waste")
 	},
 /obj/machinery/light{
 	dir = 8
@@ -106046,8 +106097,10 @@
 /turf/simulated/floor/wood,
 /area/eris/command/bridgebar)
 "eSM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/steel,
@@ -106079,8 +106132,10 @@
 	tag = "icon-poster6"
 	},
 /obj/structure/table/rack,
-/turf/simulated/floor/wood,
-/area/eris/crew_quarters/clownoffice)
+/obj/item/gun/energy/laser/practice,
+/obj/item/cell/medium/high,
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "eYg" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 8
@@ -106125,13 +106180,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
 "fbV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "fea" = (
@@ -106172,7 +106222,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/target/syndicate,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
 	tag = "icon-danger (EAST)"
@@ -106181,8 +106230,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "fmT" = (
 /obj/structure/railing/grey,
 /obj/structure/table/bar_special,
@@ -106197,6 +106246,11 @@
 /obj/machinery/chemical_dispenser/soda,
 /turf/simulated/floor/wood,
 /area/eris/command/bridgebar)
+"foC" = (
+/obj/structure/table/bar_special,
+/obj/item/deck/cards,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/eris/crew_quarters/bar)
 "fpz" = (
 /obj/machinery/camera/network/fist_section{
 	dir = 8
@@ -106306,10 +106360,6 @@
 /area/space)
 "fRb" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/item/stool/padded,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
@@ -106410,7 +106460,6 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
 "gaY" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -106419,14 +106468,16 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck1central)
-"geb" = (
-/obj/machinery/gym,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/brown_perforated,
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
+"geb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
 "gga" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -106506,6 +106557,17 @@
 	},
 /turf/simulated/floor/grass,
 /area/eris/crew_quarters/hydroponics)
+"gwu" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4;
+	tag = "icon-danger (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "gzs" = (
 /obj/structure/flora/pottedplant/random,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -106517,11 +106579,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/door/airlock,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "gBc" = (
@@ -106565,16 +106627,16 @@
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/medbay)
 "gPS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/turf/simulated/wall,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
 "gTy" = (
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -106597,6 +106659,19 @@
 	icon_state = "cargofloor1"
 	},
 /area/eris/hallway/side/eschangarb)
+"gUC" = (
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/erida/crew_quarters/firing_range)
 "gXX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -106622,13 +106697,18 @@
 /turf/simulated/floor/wood,
 /area/eris/medical/psych)
 "hdr" = (
-/obj/structure/table/bar_special,
-/obj/item/deck/cards,
-/obj/item/deck/cards,
-/obj/item/deck/cards,
-/obj/item/deck/cards,
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/eris/crew_quarters/bar)
+/obj/structure/table/rack/shelf,
+/obj/item/device/synthesized_instrument/guitar/multi,
+/obj/item/device/synthesized_instrument/violin,
+/obj/item/device/synthesized_instrument/trumpet,
+/obj/item/device/synthesized_instrument/synthesizer,
+/obj/item/device/synthesized_instrument/guitar,
+/obj/item/clothing/mask/gas/monkeymask,
+/obj/item/clothing/suit/monkeysuit,
+/obj/item/clothing/head/ushanka,
+/obj/item/clothing/under/soviet,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "hem" = (
 /obj/machinery/shower{
 	dir = 1
@@ -106685,12 +106765,11 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/reception)
 "hiv" = (
-/obj/structure/table/rack,
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/panels,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "hlf" = (
 /obj/structure/bed/chair/office/dark,
 /obj/structure/cable/green{
@@ -106704,8 +106783,11 @@
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/checkpoint/science)
 "hmj" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
@@ -106732,6 +106814,27 @@
 /obj/spawner/scrap/sparse/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5starboard)
+"hAW" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/eris/crew_quarters/bar)
 "hGN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -106802,13 +106905,22 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep/cryo)
+"hNH" = (
+/obj/structure/table/bar_special,
+/obj/structure/cyberplant{
+	pixel_x = 16;
+	pixel_y = -4;
+	possible_plants = list("emagged2-blue","emagged2-orange");
+	name = "\"Holo Dancer\""
+	},
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/eris/crew_quarters/bar)
 "hNQ" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/fitness)
@@ -106840,6 +106952,13 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
+"hVL" = (
+/obj/structure/closet/wardrobe/color/pink/artist,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "hWY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/railing/grey{
@@ -106847,6 +106966,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/hangarsupply)
+"hYW" = (
+/obj/machinery/vending/weapon_machine_practice,
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "iaf" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -107007,9 +107130,9 @@
 /turf/simulated/wall,
 /area/eris/maintenance/section3deck4central)
 "iGX" = (
-/obj/structure/table/rack,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/panels,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "iIc" = (
 /obj/effect/shuttle_landmark/merc/sec3east5,
 /turf/space,
@@ -107022,9 +107145,14 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/neotheology/chapelritualroom)
 "iKF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/bcarpet,
-/area/eris/neotheology/chapelritualroom)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/eris/crew_quarters/fitness)
 "iLh" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/steel/panels,
@@ -107131,6 +107259,28 @@
 /obj/effect/decal/warning_stripes,
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
+"jcz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Artist Studio";
+	req_access = list(28)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/artistoffice)
 "jgz" = (
 /obj/machinery/door/airlock{
 	name = "Male Showers"
@@ -107141,10 +107291,11 @@
 /area/eris/crew_quarters/sleep_male/toilet_male)
 "jir" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1
+	dir = 8;
+	tag = "icon-danger (WEST)"
 	},
-/turf/simulated/wall,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "jiP" = (
 /obj/machinery/door/blast/regular{
 	id = "scannerroom";
@@ -107237,9 +107388,13 @@
 	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/engineering/post)
+"jtR" = (
+/turf/simulated/floor/plating/under,
+/area/erida/crew_quarters/firing_range)
 "juQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
@@ -107254,7 +107409,7 @@
 "jzc" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/dark/panels,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "jAA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/carpet/bcarpet,
@@ -107351,6 +107506,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
+"jMD" = (
+/obj/effect/window_lwall_spawn/reinforced/polarized,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/bar)
 "jRe" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -107420,8 +107579,8 @@
 	pixel_y = -24
 	},
 /obj/structure/sign/semiotic/directions{
-	dir = 4;
-	pixel_x = 6;
+	dir = 8;
+	pixel_x = -6;
 	pixel_y = -24
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
@@ -107442,6 +107601,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck2port)
+"kiQ" = (
+/obj/effect/window_lwall_spawn/reinforced/polarized,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/bar)
 "klx" = (
 /obj/machinery/holomap{
 	dir = 1;
@@ -107480,12 +107644,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/range)
-"ktP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/eris/crew_quarters/fitness)
 "kvo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -107561,8 +107719,9 @@
 	},
 /area/eris/hallway/side/eschangara)
 "kLT" = (
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/clownoffice)
+/obj/structure/table/reinforced,
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "kSY" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -107687,10 +107846,11 @@
 /area/eris/engineering/shield_generator)
 "lgO" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/ears/earmuffs,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark/panels,
-/area/eris/maintenance/section3deck1central)
+/obj/machinery/recharger,
+/obj/item/clothing/ears/earmuffs,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/erida/crew_quarters/firing_range)
 "lhq" = (
 /obj/effect/shuttle_landmark/merc/medbay{
 	name = "Trading Dock Deck 4"
@@ -107778,6 +107938,11 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
+"lxb" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/erida/crew_quarters/firing_range)
 "lxN" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
@@ -107838,16 +108003,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/target/syndicate,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4;
-	tag = "icon-danger (EAST)"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "lEy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -107917,12 +108077,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
-"lPx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/steel,
-/area/eris/crew_quarters/fitness)
 "lRo" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/firealarm{
@@ -107931,6 +108085,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
+"lRv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/landmark/join/start/artist,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "lRz" = (
 /obj/structure/noticeboard{
 	pixel_x = -32
@@ -107954,19 +108117,21 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/command/bridge)
 "lRL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
 "lSz" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8;
-	tag = "icon-danger (WEST)"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/eris/maintenance/section3deck1central)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4;
+	tag = "icon-danger (EAST)"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "lSA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -108120,6 +108285,18 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
+"muH" = (
+/obj/spawner/traps/low_chance,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck1central)
 "mvb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -108154,8 +108331,16 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/maintenance/junk)
 "mAA" = (
-/turf/simulated/wall,
-/area/eris/crew_quarters/clownoffice)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck1central)
 "mBD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -108303,13 +108488,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
-"mUB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/steel,
-/area/eris/crew_quarters/fitness)
 "mVe" = (
 /obj/machinery/door/airlock{
 	id_tag = "BridgeToilet1";
@@ -108337,8 +108515,8 @@
 	tag = "icon-danger (EAST)"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "naB" = (
 /obj/machinery/shower{
 	dir = 1
@@ -108371,6 +108549,9 @@
 	light_power = 2;
 	light_range = 3;
 	pixel_y = 32
+	},
+/obj/structure/bed/chair/custom/bar_special{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
@@ -108408,10 +108589,7 @@
 /area/eris/quartermaster/hangarsupply)
 "nsi" = (
 /obj/machinery/gym/toughness,
-/turf/simulated/floor/reinforced{
-	name = "engine floor";
-	oxygen = 0
-	},
+/turf/simulated/floor/reinforced,
 /area/eris/crew_quarters/fitness)
 "ntp" = (
 /obj/machinery/hologram/holopad,
@@ -108425,6 +108603,24 @@
 	},
 /turf/space,
 /area/space)
+"nvS" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/eris/crew_quarters/bar)
 "nAL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -108571,17 +108767,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/item/target/syndicate,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8;
-	tag = "icon-danger (WEST)"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/eris/maintenance/section3deck1central)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/erida/crew_quarters/firing_range)
 "nUy" = (
 /obj/machinery/door/airlock/glass_security{
 	name = "Security Post";
@@ -108590,13 +108782,12 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/security/checkpoint/medical)
 "nVL" = (
-/obj/machinery/door/airlock/glass{
-	name = "Holodeck Door"
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/dark/panels,
-/area/eris/maintenance/section3deck1central)
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/item/clothing/ears/earmuffs,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/erida/crew_quarters/firing_range)
 "nWN" = (
 /obj/structure/table/marble,
 /obj/item/soap/nanotrasen,
@@ -108609,7 +108800,9 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/eschangarb)
 "nXG" = (
-/obj/item/stool/custom/bar_special,
+/obj/structure/bed/chair/custom/bar_special{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
 "nYI" = (
@@ -108774,6 +108967,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
+"ouK" = (
+/obj/structure/railing{
+	dir = 8;
+	tag = "icon-railing0 (WEST)"
+	},
+/turf/simulated/floor/plating/under,
+/area/erida/crew_quarters/firing_range)
 "ouQ" = (
 /obj/structure/table/rack,
 /obj/item/tool/hammer/dumbbell{
@@ -108782,10 +108982,7 @@
 /obj/item/tool/hammer/dumbbell{
 	pixel_y = 7
 	},
-/turf/simulated/floor/reinforced{
-	name = "engine floor";
-	oxygen = 0
-	},
+/turf/simulated/floor/reinforced,
 /area/eris/crew_quarters/fitness)
 "ovh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -108906,8 +109103,8 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/wall,
+/area/erida/crew_quarters/firing_range)
 "oGr" = (
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Restrooms"
@@ -109013,6 +109210,8 @@
 "pbu" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
 "pij" = (
@@ -109058,10 +109257,23 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
 "pto" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/reinforced/polarized,
-/turf/simulated/floor/plating,
-/area/eris/crew_quarters/bar)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/third_section,
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
+"ptr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "ptL" = (
 /obj/structure/closet/self_pacification,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -109109,20 +109321,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
-"pGe" = (
-/obj/structure/table/standard,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel,
-/area/eris/crew_quarters/fitness)
-"pGN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/wall/r_wall,
-/area/eris/maintenance/section3deck1central)
 "pGT" = (
 /obj/structure/bed/chair/shuttle{
 	dir = 1;
@@ -109194,14 +109392,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
-"pWC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/bed/chair/wood{
-	dir = 1
-	},
-/obj/landmark/join/start/hydro,
-/turf/simulated/floor/carpet/bcarpet,
-/area/eris/neotheology/chapelritualroom)
 "qaq" = (
 /obj/structure/toilet{
 	dir = 4
@@ -109255,6 +109445,9 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/engineering/atmos/storage)
+"qmu" = (
+/turf/simulated/open,
+/area/erida/crew_quarters/firing_range)
 "qmN" = (
 /obj/structure/bed/chair/shuttle,
 /obj/spawner/scrap,
@@ -109354,6 +109547,7 @@
 	dir = 1;
 	pixel_y = -23
 	},
+/obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
 "qEt" = (
@@ -109386,11 +109580,13 @@
 /turf/simulated/floor/wood,
 /area/eris/command/courtroom)
 "qOV" = (
-/obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/wall/r_wall,
-/area/eris/maintenance/section3deck1central)
+/obj/machinery/door/airlock/glass{
+	name = "Holodeck Door"
+	},
+/turf/simulated/floor/tiled/steel/cargo,
+/area/erida/crew_quarters/firing_range)
 "qRc" = (
 /obj/structure/jtb_pillar,
 /turf/simulated/floor/tiled/dark/danger,
@@ -109451,6 +109647,9 @@
 /area/eris/quartermaster/storage)
 "qXB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/steel,
@@ -109536,11 +109735,13 @@
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
 "rne" = (
-/obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/glass{
+	name = "Holodeck Door"
+	},
 /obj/machinery/door/firedoor,
-/turf/simulated/wall/r_wall,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/tiled/steel/cargo,
+/area/erida/crew_quarters/firing_range)
 "rnm" = (
 /obj/structure/table/standard,
 /obj/machinery/light{
@@ -109591,6 +109792,11 @@
 "rBd" = (
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics/garden)
+"rBg" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/space,
+/area/erida/crew_quarters/firing_range)
 "rBy" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/railing{
@@ -109671,6 +109877,9 @@
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
 "rNt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -109739,6 +109948,11 @@
 /obj/effect/floor_decal/semiotic/storage,
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/warden)
+"rWI" = (
+/obj/structure/table/bar_special,
+/obj/item/deck/cards,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/eris/crew_quarters/bar)
 "rXZ" = (
 /mob/living/simple_animal/cat/fluff/bones,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -109747,9 +109961,6 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/breakroom)
 "rZh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
 /obj/structure/table/marble,
 /obj/item/book/ritual/cruciform,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -109794,8 +110005,12 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8;
+	tag = "icon-danger (WEST)"
+	},
 /turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "snG" = (
 /obj/machinery/atmospherics/valve/digital{
 	dir = 4;
@@ -109803,6 +110018,14 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/engine_room)
+"sqX" = (
+/obj/structure/closet/secure_closet/personal/artist,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/third_section{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "sss" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -109907,12 +110130,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_female/toilet_female)
-"sBc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/eris/crew_quarters/fitness)
 "sBX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -109920,21 +110137,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/target/syndicate,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8;
-	tag = "icon-danger (WEST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/eris/maintenance/section3deck1central)
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4;
+	tag = "icon-danger (EAST)"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
+"sCp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4;
+	tag = "icon-danger (EAST)"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "sCt" = (
 /obj/structure/catwalk,
 /obj/structure/cable{
@@ -110013,8 +110230,8 @@
 /turf/simulated/floor/reinforced,
 /area/eris/medical/chemstor)
 "sLu" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/oldtele)
@@ -110050,6 +110267,13 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
+"sQT" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/obj/landmark/join/start/artist,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "sRP" = (
 /obj/effect/floor_decal/semiotic/airlock,
 /turf/simulated/floor/tiled/white,
@@ -110133,13 +110357,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
-"tnB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/steel,
-/area/eris/crew_quarters/fitness)
 "toI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
@@ -110186,11 +110403,28 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck4central)
 "tCi" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/oldtele)
+"tCZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "tEu" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/lights/tubes,
@@ -110203,6 +110437,13 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/quartermaster/hangarsupply)
+"tHV" = (
+/obj/machinery/autolathe/artist_bench,
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "tMc" = (
 /obj/machinery/camera/network/engineering{
 	dir = 8
@@ -110308,6 +110549,10 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/bioreactor)
+"ufA" = (
+/obj/item/gun/energy/laser/paladin,
+/turf/simulated/wall/r_wall,
+/area/eris/maintenance/section3deck5port)
 "uga" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
@@ -110430,6 +110675,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/command/bridgetoilet)
 "uvC" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/fitness)
 "uvI" = (
@@ -110448,6 +110696,14 @@
 /obj/spawner/pack/tech_loot/low_chance,
 /turf/simulated/floor/tiled/white/panels,
 /area/eris/rnd/scient)
+"uAg" = (
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/erida/crew_quarters/firing_range)
 "uAu" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -110472,7 +110728,7 @@
 "uEA" = (
 /obj/machinery/light,
 /turf/simulated/floor/tiled/dark/panels,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "uFU" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -110571,6 +110827,11 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
+"uXs" = (
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/artistoffice)
 "uXF" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
@@ -110593,6 +110854,17 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/engine_room)
+"uZF" = (
+/obj/structure/closet/secure_closet/personal/artist,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
+"vbq" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "vbX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -110638,8 +110910,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/plating/under,
+/area/erida/crew_quarters/firing_range)
 "vhD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -110652,9 +110924,13 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
 "vjw" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating)
+/obj/item/contraband/poster/placed{
+	icon_state = "poster6";
+	pixel_x = -32;
+	tag = "icon-poster6"
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "vkt" = (
 /obj/machinery/door/window/eastright{
 	name = "Research Desk";
@@ -110724,6 +111000,9 @@
 	dir = 1;
 	pixel_y = 26
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/fitness)
 "vta" = (
@@ -110758,22 +111037,24 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section3)
 "vAE" = (
-/turf/simulated/wall/r_wall,
-/area/eris/crew_quarters/clownoffice)
+/obj/item/target/syndicate,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/erida/crew_quarters/firing_range)
 "vAO" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
 /area/eris/crew_quarters/sleep_male/toilet_male)
 "vBm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
+"vDi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "vEQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -110882,6 +111163,21 @@
 /obj/machinery/neotheology/cruciformforge,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/neotheology/chapelritualroom)
+"vXJ" = (
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "North APC";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "vZa" = (
 /obj/machinery/door/blast/regular{
 	id = "scannerroom";
@@ -110932,12 +111228,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
-"wgR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/wall,
-/area/eris/crew_quarters/fitness)
 "wja" = (
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/wall/r_wall,
@@ -110954,6 +111244,9 @@
 /turf/simulated/floor/tiled/steel/danger,
 /area/eris/engineering/engine_room)
 "wkU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -110987,8 +111280,11 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
 "wns" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
@@ -111078,6 +111374,18 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
+"wBV" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "wEJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -111094,10 +111402,7 @@
 /area/eris/engineering/long_range_scanner)
 "wNc" = (
 /obj/machinery/gym/robustness,
-/turf/simulated/floor/reinforced{
-	name = "engine floor";
-	oxygen = 0
-	},
+/turf/simulated/floor/reinforced,
 /area/eris/crew_quarters/fitness)
 "wOW" = (
 /obj/structure/closet/secure_closet/medicine,
@@ -111126,15 +111431,6 @@
 	},
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/hallway/side/bridgehallway)
-"wWI" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/crew_quarters/fitness)
 "wXf" = (
 /obj/structure/closet/secure_closet/medicine,
 /obj/machinery/light/small{
@@ -111217,7 +111513,7 @@
 "xou" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/dark/panels,
-/area/eris/maintenance/section3deck1central)
+/area/erida/crew_quarters/firing_range)
 "xrS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4;
@@ -123689,7 +123985,7 @@ aaa
 aaa
 alg
 alg
-alg
+ufA
 alg
 alg
 asp
@@ -124307,7 +124603,7 @@ ayC
 azl
 avN
 ccJ
-cem
+ceU
 ceU
 avN
 aaa
@@ -124508,9 +124804,9 @@ axu
 ayy
 azj
 avN
-bZP
-avK
-bkn
+btZ
+ceU
+ceU
 avN
 aaa
 aaa
@@ -136618,7 +136914,7 @@ aaa
 aaa
 aaa
 avn
-awG
+ata
 cgl
 auV
 btk
@@ -165711,8 +166007,8 @@ byR
 bXY
 bXY
 rZh
-iKF
-pWC
+bXY
+sAr
 sAr
 bXY
 bGD
@@ -169555,11 +169851,11 @@ bBE
 cYb
 cjp
 aqa
-cQe
-cQe
-cQe
-cQe
-cQe
+sqX
+lRv
+ptr
+vjw
+uZF
 aqa
 cjp
 dXa
@@ -169757,11 +170053,11 @@ anJ
 cYO
 swy
 aqa
+ewQ
+erC
 cQM
-cQM
-cQM
-cQM
-cQM
+bmS
+chZ
 aqa
 dMl
 clZ
@@ -169958,13 +170254,13 @@ cih
 anJ
 cWy
 apF
-pto
-cPv
-cPv
-cPv
-cPv
-cPv
-pto
+aqa
+tHV
+sQT
+erI
+erC
+hdr
+aqa
 apF
 dTC
 anJ
@@ -170161,11 +170457,11 @@ anJ
 cXK
 cjw
 aqa
-cPv
-cPv
-cPv
-cPv
-cPv
+vXJ
+chV
+tCZ
+vDi
+hVL
 aqa
 dJD
 cmo
@@ -170360,17 +170656,17 @@ chE
 anJ
 cJV
 anJ
-aqa
+kiQ
 bCz
 aqa
-aqV
-aqV
-aqV
-aqV
-aqV
+uXs
+uXs
+jcz
+uXs
+uXs
 aqa
 sXq
-aqa
+jMD
 anJ
 apF
 anJ
@@ -170566,8 +170862,8 @@ cCG
 apF
 cjM
 bTn
-cil
-ckE
+bfC
+nvS
 cjc
 clX
 cjM
@@ -170769,7 +171065,7 @@ apF
 apF
 cim
 cld
-cld
+hAW
 cjd
 cpU
 clV
@@ -173365,7 +173661,7 @@ aEO
 bfn
 aHX
 apJ
-hhc
+cDN
 hhc
 uEj
 apJ
@@ -174594,13 +174890,13 @@ auG
 aaa
 abF
 bbk
-erj
-erj
-erj
+cgO
+cgO
+cgO
 bzN
-erj
-erj
-erj
+cgO
+cgO
+cgO
 cOy
 cix
 cix
@@ -174796,13 +175092,13 @@ aad
 aaa
 abF
 abF
-erj
+cgO
 cgQ
-bmS
+chd
 bpZ
 ctX
 cxt
-ero
+bgH
 cMt
 ciB
 ciB
@@ -174998,13 +175294,13 @@ aad
 aaa
 abF
 abF
-erj
+cgO
 ctb
 chd
 chu
 chH
 chT
-ero
+bgH
 bgH
 bAN
 bAN
@@ -175200,13 +175496,13 @@ aaa
 aaa
 abF
 abF
-erj
+cgO
 ctp
 che
 chx
 chI
-chV
-vjw
+cgY
+bAN
 ciC
 ciC
 ciD
@@ -175402,13 +175698,13 @@ aaa
 aaa
 abF
 abF
-erj
+cgO
 ctq
 chh
 crA
 chJ
-chZ
-vjw
+chJ
+bAN
 ciC
 ciC
 cjE
@@ -175604,13 +175900,13 @@ aaa
 aaa
 bVX
 bVX
-erj
-ero
+cgO
+bgH
 bzI
-ero
-vjw
-vjw
-ero
+bgH
+bAN
+bAN
+bgH
 cCj
 cjl
 cjI
@@ -209556,7 +209852,7 @@ cjQ
 cjQ
 czL
 dXQ
-cjQ
+foC
 lsO
 rPI
 cBC
@@ -209957,7 +210253,7 @@ ctE
 ewf
 cil
 cyV
-cjQ
+foC
 czL
 dXQ
 cyV
@@ -211164,8 +211460,8 @@ bAX
 dJL
 aqa
 bSB
-cJQ
-nXG
+apF
+apF
 apF
 apF
 dYi
@@ -211366,8 +211662,8 @@ dHg
 bWk
 aqa
 nkF
-hdr
-nXG
+mwS
+apF
 apF
 apF
 aAs
@@ -211567,7 +211863,7 @@ buH
 evx
 dJV
 aqa
-apF
+hNH
 cJQ
 nXG
 apF
@@ -211769,9 +212065,9 @@ buH
 evw
 bWk
 aqa
-apF
-apF
-apF
+cJQ
+cJQ
+nXG
 apF
 apF
 cAL
@@ -211779,7 +212075,7 @@ xIO
 ctE
 dXW
 kXR
-cJQ
+rWI
 chY
 cpm
 cpm
@@ -246716,7 +247012,7 @@ eaj
 awr
 cDi
 vtO
-dtS
+cmE
 mvF
 ebW
 ebW
@@ -247925,7 +248221,7 @@ abF
 abF
 awr
 cKw
-cDM
+dtS
 awr
 nsi
 eoA
@@ -248134,7 +248430,7 @@ eoA
 ydA
 cDu
 vrq
-uvC
+kvo
 cDu
 onI
 cDM
@@ -248333,7 +248629,7 @@ cDM
 dxq
 ouQ
 eoA
-cDM
+cJR
 cDu
 hmj
 dss
@@ -248538,7 +248834,7 @@ eoA
 qCl
 cDu
 gzK
-ata
+cDu
 cDu
 onI
 cDM
@@ -248737,10 +249033,10 @@ cDM
 dxq
 ouQ
 eoA
-cJR
-cDi
-ktP
-pGe
+cDM
+emk
+qXB
+oyg
 cDu
 rnm
 cDM
@@ -248939,9 +249235,9 @@ cDM
 dxq
 wNc
 eoA
-cDN
-cDi
-mUB
+cDM
+erg
+qXB
 fRb
 cDu
 onI
@@ -249142,7 +249438,7 @@ dxq
 ouQ
 eoA
 cDM
-cDM
+geb
 wkU
 vBm
 cDu
@@ -249344,8 +249640,8 @@ dxq
 ouQ
 eoA
 cDM
-cDM
-wkU
+gPS
+iKF
 lRL
 wns
 pbu
@@ -249547,10 +249843,10 @@ wNc
 eoA
 oRV
 uvC
-geb
+oRV
 awt
 rNt
-wgR
+cDu
 hNQ
 gzs
 awr
@@ -249749,11 +250045,11 @@ awr
 dxq
 dxq
 bhE
-cDL
+dxq
 cDL
 dBM
-gPS
-sBc
+cDu
+cDu
 awr
 awr
 dHk
@@ -249951,11 +250247,11 @@ cEy
 cEy
 cDi
 cDi
-lPx
-tnB
+cDi
+cDi
 qXB
-ktP
-wWI
+cDi
+cEy
 euq
 ovX
 cDi
@@ -250154,7 +250450,7 @@ ebV
 cDi
 cDi
 cDi
-lPx
+cDi
 eSM
 fbV
 ecR
@@ -250550,7 +250846,7 @@ dqI
 dqI
 enV
 awr
-emk
+awr
 exz
 eas
 cFK
@@ -288125,15 +288421,15 @@ dXi
 boN
 boN
 boS
-boS
-enU
-boS
+ebc
+gUC
+ebc
 eqI
 eqI
-boS
-boS
+ouK
+ouK
 bsI
-erg
+ouK
 boS
 elC
 boS
@@ -288327,15 +288623,15 @@ dXi
 aNK
 cNH
 aCh
-boS
-erX
-iGX
-dXi
-cNH
-cNH
 ebc
+wBV
+iGX
+vbq
+eqI
+qmu
+qmu
 vfA
-btZ
+jtR
 dXi
 bkF
 boS
@@ -288529,15 +288825,15 @@ dXi
 aNL
 cNH
 cNH
-elC
+uAg
 erX
 dgs
-lgO
-cxK
-cxK
-cxK
+eqI
+ebc
+ebc
+ebc
 nSC
-btZ
+ebc
 dXi
 bkF
 boS
@@ -288727,19 +289023,19 @@ alb
 alb
 aaa
 abF
-vAE
-mAA
-mAA
-mAA
-mAA
+eqI
+ebc
+ebc
+ebc
+ebc
 gaY
 jzc
 qOV
 mZv
 mZv
-mZv
+gwu
 fly
-btZ
+ero
 dXi
 bkF
 boS
@@ -288929,7 +289225,7 @@ abF
 abF
 aaa
 abF
-vAE
+eqI
 erw
 eWR
 erw
@@ -288937,12 +289233,12 @@ emG
 erX
 dgs
 nVL
-oCA
-cNH
-slc
-vfA
-btZ
-cNH
+cIg
+cIg
+cIg
+lDx
+vAE
+dXi
 bkF
 boS
 bvj
@@ -289131,20 +289427,20 @@ abF
 abF
 aaa
 abF
-vAE
+eqI
 erx
-kLT
-kLT
+dgs
+dgs
 emG
 erX
 uEA
-dXi
+rBg
 jir
-boS
-boS
-bsI
-btZ
-cNH
+jir
+slc
+cxK
+jir
+dXi
 bkF
 boS
 boS
@@ -289333,20 +289629,20 @@ abF
 abF
 aaa
 abF
-vAE
-erw
-kLT
+eqI
+hYW
+dgs
 erF
 enL
 exs
 dgs
-nVL
+eqI
 oCA
-cNH
 ebc
-vfA
-btZ
-cNH
+ebc
+nSC
+ebc
+dXi
 bkF
 boS
 aNH
@@ -289535,19 +289831,19 @@ abF
 abF
 aaa
 abF
-vAE
-erw
-kLT
+eqI
+hYW
+dgs
 erG
 emG
 erX
 xou
 rne
-lSz
-lSz
+sCp
+sCp
 lSz
 sBX
-btZ
+ero
 dXi
 bkF
 boN
@@ -289736,9 +290032,9 @@ abF
 abF
 abF
 aaa
-vAE
-vAE
-vAE
+eqI
+eqI
+eqI
 erz
 erH
 emG
@@ -289749,7 +290045,7 @@ cIg
 cIg
 cIg
 lDx
-pGN
+vAE
 dXi
 bkF
 boN
@@ -289938,20 +290234,20 @@ abF
 abF
 abF
 aaa
-vAE
+eqI
 ezg
 ehJ
+dgs
 kLT
-kLT
-emG
-erX
+ebc
+pto
 hiv
-dXi
-cNH
-cNH
+lxb
+jir
+jir
 slc
-vfA
-btZ
+cxK
+jir
 dXi
 bkF
 boS
@@ -290140,20 +290436,20 @@ abF
 abF
 abF
 aaa
-vAE
+eqI
 erl
-vAE
+eqI
 ezm
-erI
-mAA
+dgs
+ebc
 enU
-boS
-eqI
-eqI
-boS
-boS
-bsI
-erg
+ebc
+emG
+emG
+ebc
+ebc
+nSC
+ebc
 boS
 elC
 boS
@@ -290342,13 +290638,13 @@ enI
 enI
 abF
 aaa
-vAE
+eqI
 erm
-vAE
+eqI
 ezn
 ezq
-mAA
-erP
+ebc
+muH
 bma
 bmU
 bqa
@@ -290544,13 +290840,13 @@ sJL
 enI
 abF
 aaa
-vAE
-vAE
-vAE
-erC
+eqI
+eqI
+eqI
+xou
 erK
+ebc
 mAA
-erO
 cNH
 cNH
 bqn
@@ -290748,11 +291044,11 @@ aaa
 aaa
 dXi
 aCh
-mAA
-mAA
+ebc
+ebc
 ejK
+ebc
 mAA
-erO
 cNH
 cNH
 bqn
@@ -291155,7 +291451,7 @@ etO
 etX
 ewd
 ewp
-ewQ
+esz
 ext
 exu
 exN

--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -28443,16 +28443,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/lab)
 "bmS" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck1central)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "bmT" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -49208,12 +49201,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
 "chJ" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/erida/crew_quarters/firing_range)
+/obj/structure/table/rack/shelf,
+/obj/spawner/material/building,
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "chK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -49287,21 +49278,16 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/crew_quarters/janitor)
 "chV" = (
+/obj/structure/table/standard,
+/obj/machinery/recharger,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
+/obj/item/stack/material/wood/random,
+/obj/item/stack/material/steel/random,
+/turf/simulated/floor/carpet/gaycarpet,
 /area/eris/crew_quarters/artistoffice)
 "chW" = (
 /obj/structure/cable/green{
@@ -49333,10 +49319,17 @@
 /turf/simulated/wall/r_wall,
 /area/eris/hallway/main/section3)
 "chZ" = (
-/obj/structure/table/rack/shelf,
-/obj/spawner/material/building,
-/turf/simulated/floor/tiled/steel,
-/area/eris/quartermaster/storage)
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "cia" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
@@ -56092,8 +56085,21 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cxK" = (
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/eris/crew_quarters/artistoffice)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8;
+	tag = "icon-danger (WEST)"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "cxL" = (
 /obj/spawner/material/building,
 /obj/spawner/material/building,
@@ -60651,9 +60657,8 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/crew_quarters/janitor)
 "cIg" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/eris/crew_quarters/artistoffice)
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/erida/crew_quarters/firing_range)
 "cIh" = (
 /obj/item/modular_computer/console/preset/engineering/power,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -64106,16 +64111,14 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
 "cQM" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/light,
-/turf/simulated/floor/carpet/gaycarpet,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/crew_quarters/artistoffice)
 "cQN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
@@ -70879,12 +70882,7 @@
 /turf/simulated/floor/tiled/white/danger,
 /area/eris/rnd/xenobiology)
 "dgs" = (
-/obj/machinery/door/airlock/maintenance_common{
-	name = "Service Maintenance";
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techmaint_cargo,
+/turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
 "dgt" = (
 /turf/simulated/wall/r_wall,
@@ -91683,7 +91681,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/anomalisoltwo)
 "ebc" = (
-/turf/simulated/open,
+/turf/simulated/wall,
 /area/erida/crew_quarters/firing_range)
 "ebd" = (
 /turf/simulated/floor/tiled/dark,
@@ -96640,15 +96638,10 @@
 /turf/simulated/open,
 /area/eris/maintenance/section4deck1central)
 "emG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/eris/crew_quarters/artistoffice)
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/erida/crew_quarters/firing_range)
 "emH" = (
 /obj/structure/plasticflaps/mining,
 /turf/simulated/floor/plating/under,
@@ -98241,9 +98234,7 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/library)
 "eqI" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/erida/crew_quarters/firing_range)
 "eqJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -98558,9 +98549,10 @@
 /area/eris/medical/surgery)
 "ero" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 1
+	dir = 4;
+	tag = "icon-danger (EAST)"
 	},
-/turf/simulated/wall,
+/turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
 "erp" = (
 /obj/machinery/light,
@@ -98639,7 +98631,7 @@
 /area/erida/crew_quarters/firing_range)
 "erx" = (
 /obj/machinery/camera/network/third_section,
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
 "ery" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -98657,7 +98649,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
 "erA" = (
 /obj/structure/table/standard,
@@ -98674,12 +98666,8 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
 "erC" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/panels,
-/area/erida/crew_quarters/firing_range)
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "erD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -98721,8 +98709,14 @@
 /turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
 "erI" = (
-/turf/simulated/floor/tiled/techmaint,
-/area/erida/crew_quarters/firing_range)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "erJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -98741,7 +98735,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
 "erL" = (
 /obj/machinery/door/firedoor,
@@ -98870,8 +98864,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
@@ -101194,12 +101187,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
 "ewQ" = (
-/obj/structure/railing{
-	dir = 8;
-	tag = "icon-railing0 (WEST)"
+/obj/item/modular_computer/console/preset/civilian/professional,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/plating/under,
-/area/erida/crew_quarters/firing_range)
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "ewR" = (
 /obj/structure/table/standard,
 /obj/item/clothing/mask/breath,
@@ -102345,7 +102338,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
 "ezn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -102381,7 +102374,7 @@
 	dir = 1;
 	pixel_y = -23
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
 "ezr" = (
 /obj/structure/disposalpipe/segment,
@@ -106024,24 +106017,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/space)
-"eNW" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/bar_dance,
-/area/eris/crew_quarters/bar)
 "eOl" = (
 /obj/structure/catwalk,
 /obj/spawner/junk/low_chance,
@@ -106233,13 +106208,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/quartermaster/hangarsupply)
-"fjw" = (
-/obj/item/modular_computer/console/preset/civilian/professional,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "flx" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -106278,6 +106246,11 @@
 /obj/machinery/chemical_dispenser/soda,
 /turf/simulated/floor/wood,
 /area/eris/command/bridgebar)
+"foC" = (
+/obj/structure/table/bar_special,
+/obj/item/deck/cards,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/eris/crew_quarters/bar)
 "fpz" = (
 /obj/machinery/camera/network/fist_section{
 	dir = 8
@@ -106306,23 +106279,6 @@
 	},
 /turf/simulated/floor/tiled/white/panels,
 /area/eris/rnd/scient)
-"fue" = (
-/obj/structure/table/rack/shelf,
-/obj/item/device/synthesized_instrument/guitar/multi,
-/obj/item/device/synthesized_instrument/violin,
-/obj/item/device/synthesized_instrument/trumpet,
-/obj/item/device/synthesized_instrument/synthesizer,
-/obj/item/device/synthesized_instrument/guitar,
-/obj/item/clothing/mask/gas/monkeymask,
-/obj/item/clothing/suit/monkeysuit,
-/obj/item/clothing/head/ushanka,
-/obj/item/clothing/under/soviet,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
-"fzp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "fzU" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4;
@@ -106463,18 +106419,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/quartermaster/hangarsupply)
-"fWr" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/third_section,
-/turf/simulated/floor/tiled/techmaint,
-/area/erida/crew_quarters/firing_range)
 "fWC" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -106579,12 +106523,6 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
-"gpl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/eris/crew_quarters/artistoffice)
 "gsx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -106619,28 +106557,17 @@
 	},
 /turf/simulated/floor/grass,
 /area/eris/crew_quarters/hydroponics)
-"gyW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Artist Studio";
-	req_access = list(28)
+"gwu" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4;
+	tag = "icon-danger (EAST)"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/crew_quarters/artistoffice)
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "gzs" = (
 /obj/structure/flora/pottedplant/random,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -106692,10 +106619,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/eris/rnd/podbay)
-"gOt" = (
-/obj/item/gun/energy/laser/paladin,
-/turf/simulated/wall/r_wall,
-/area/eris/maintenance/section3deck5port)
 "gPD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -106736,6 +106659,19 @@
 	icon_state = "cargofloor1"
 	},
 /area/eris/hallway/side/eschangarb)
+"gUC" = (
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/erida/crew_quarters/firing_range)
 "gXX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -106761,10 +106697,16 @@
 /turf/simulated/floor/wood,
 /area/eris/medical/psych)
 "hdr" = (
-/obj/structure/closet/wardrobe/color/pink/artist,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/structure/table/rack/shelf,
+/obj/item/device/synthesized_instrument/guitar/multi,
+/obj/item/device/synthesized_instrument/violin,
+/obj/item/device/synthesized_instrument/trumpet,
+/obj/item/device/synthesized_instrument/synthesizer,
+/obj/item/device/synthesized_instrument/guitar,
+/obj/item/clothing/mask/gas/monkeymask,
+/obj/item/clothing/suit/monkeysuit,
+/obj/item/clothing/head/ushanka,
+/obj/item/clothing/under/soviet,
 /turf/simulated/floor/carpet/gaycarpet,
 /area/eris/crew_quarters/artistoffice)
 "hem" = (
@@ -106823,6 +106765,9 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/reception)
 "hiv" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
 "hlf" = (
@@ -106869,6 +106814,27 @@
 /obj/spawner/scrap/sparse/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5starboard)
+"hAW" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/eris/crew_quarters/bar)
 "hGN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -106933,15 +106899,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section1deck4central)
-"hML" = (
-/turf/simulated/floor/plating/under,
-/area/erida/crew_quarters/firing_range)
 "hNy" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep/cryo)
+"hNH" = (
+/obj/structure/table/bar_special,
+/obj/structure/cyberplant{
+	pixel_x = 16;
+	pixel_y = -4;
+	possible_plants = list("emagged2-blue","emagged2-orange");
+	name = "\"Holo Dancer\""
+	},
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/eris/crew_quarters/bar)
 "hNQ" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -106979,6 +106952,13 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
+"hVL" = (
+/obj/structure/closet/wardrobe/color/pink/artist,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "hWY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/railing/grey{
@@ -106986,6 +106966,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/hangarsupply)
+"hYW" = (
+/obj/machinery/vending/weapon_machine_practice,
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "iaf" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -107117,18 +107101,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section2)
-"ixz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/erida/crew_quarters/firing_range)
 "iyV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -107161,10 +107133,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
-"iHQ" = (
-/obj/effect/window_lwall_spawn/reinforced/polarized,
-/turf/simulated/floor/plating,
-/area/eris/crew_quarters/bar)
 "iIc" = (
 /obj/effect/shuttle_landmark/merc/sec3east5,
 /turf/space,
@@ -107291,6 +107259,28 @@
 /obj/effect/decal/warning_stripes,
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
+"jcz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Artist Studio";
+	req_access = list(28)
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/artistoffice)
 "jgz" = (
 /obj/machinery/door/airlock{
 	name = "Male Showers"
@@ -107398,6 +107388,9 @@
 	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/engineering/post)
+"jtR" = (
+/turf/simulated/floor/plating/under,
+/area/erida/crew_quarters/firing_range)
 "juQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -107405,18 +107398,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
-"jwG" = (
-/obj/structure/table/bar_special,
-/obj/item/deck/cards,
-/turf/simulated/floor/tiled/steel/bar_light,
-/area/eris/crew_quarters/bar)
-"jxB" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4;
-	tag = "icon-danger (EAST)"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/erida/crew_quarters/firing_range)
 "jxG" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
@@ -107525,6 +107506,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
+"jMD" = (
+/obj/effect/window_lwall_spawn/reinforced/polarized,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/bar)
 "jRe" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -107616,6 +107601,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck2port)
+"kiQ" = (
+/obj/effect/window_lwall_spawn/reinforced/polarized,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/bar)
 "klx" = (
 /obj/machinery/holomap{
 	dir = 1;
@@ -107654,11 +107644,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/range)
-"kte" = (
-/obj/effect/window_lwall_spawn/reinforced/polarized,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/eris/crew_quarters/bar)
 "kvo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -107953,6 +107938,11 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
+"lxb" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/erida/crew_quarters/firing_range)
 "lxN" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
@@ -108073,21 +108063,6 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck1central)
-"lND" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "lOA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/cargo,
@@ -108110,6 +108085,15 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
+"lRv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/landmark/join/start/artist,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "lRz" = (
 /obj/structure/noticeboard{
 	pixel_x = -32
@@ -108142,6 +108126,9 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
 	tag = "icon-danger (EAST)"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
@@ -108298,16 +108285,18 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
-"muG" = (
-/obj/structure/table/bar_special,
-/obj/structure/cyberplant{
-	pixel_x = 16;
-	pixel_y = -4;
-	possible_plants = list("emagged2-blue","emagged2-orange");
-	name = "\"Holo Dancer\""
+"muH" = (
+/obj/spawner/traps/low_chance,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/eris/crew_quarters/bar)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck1central)
 "mvb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -108342,15 +108331,16 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/maintenance/junk)
 "mAA" = (
-/turf/simulated/wall,
-/area/erida/crew_quarters/firing_range)
-"mBA" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/item/clothing/ears/earmuffs,
-/turf/simulated/floor/tiled/steel/cargo,
-/area/erida/crew_quarters/firing_range)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck1central)
 "mBD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -108613,6 +108603,24 @@
 	},
 /turf/space,
 /area/space)
+"nvS" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/eris/crew_quarters/bar)
 "nAL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -108720,18 +108728,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
-"nON" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/item/stack/material/wood/random,
-/obj/item/stack/material/steel/random,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "nQt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -108786,7 +108782,11 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/security/checkpoint/medical)
 "nVL" = (
-/turf/simulated/wall/r_wall,
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/item/clothing/ears/earmuffs,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/erida/crew_quarters/firing_range)
 "nWN" = (
 /obj/structure/table/marble,
@@ -108799,17 +108799,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/eschangarb)
-"nXt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4;
-	tag = "icon-danger (EAST)"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/erida/crew_quarters/firing_range)
 "nXG" = (
 /obj/structure/bed/chair/custom/bar_special{
 	dir = 1
@@ -108978,6 +108967,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
+"ouK" = (
+/obj/structure/railing{
+	dir = 8;
+	tag = "icon-railing0 (WEST)"
+	},
+/turf/simulated/floor/plating/under,
+/area/erida/crew_quarters/firing_range)
 "ouQ" = (
 /obj/structure/table/rack,
 /obj/item/tool/hammer/dumbbell{
@@ -109104,7 +109100,10 @@
 /turf/simulated/floor/hull,
 /area/space)
 "oCA" = (
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 1
+	},
+/turf/simulated/wall,
 /area/erida/crew_quarters/firing_range)
 "oGr" = (
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -109215,10 +109214,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
-"pcO" = (
-/obj/structure/closet/secure_closet/personal/artist,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "pij" = (
 /obj/machinery/requests_console{
 	dir = 1;
@@ -109262,10 +109257,23 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
 "pto" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cargo,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/third_section,
+/turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
+"ptr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "ptL" = (
 /obj/structure/closet/self_pacification,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -109296,11 +109304,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
-"pzk" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/obj/machinery/door/firedoor,
-/turf/space,
-/area/erida/crew_quarters/firing_range)
 "pEk" = (
 /obj/machinery/door/airlock{
 	name = "Male Restroom"
@@ -109442,6 +109445,9 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/engineering/atmos/storage)
+"qmu" = (
+/turf/simulated/open,
+/area/erida/crew_quarters/firing_range)
 "qmN" = (
 /obj/structure/bed/chair/shuttle,
 /obj/spawner/scrap,
@@ -109767,20 +109773,6 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
-"rwv" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/obj/landmark/join/start/artist,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/eris/crew_quarters/artistoffice)
-"rxK" = (
-/obj/machinery/autolathe/artist_bench,
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "rze" = (
 /obj/structure/table/rack,
 /obj/spawner/lowkeyrandom,
@@ -109800,6 +109792,11 @@
 "rBd" = (
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics/garden)
+"rBg" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/space,
+/area/erida/crew_quarters/firing_range)
 "rBy" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/railing{
@@ -109818,19 +109815,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/eris/engineering/atmos/storage)
-"rEg" = (
-/obj/machinery/door/airlock/maintenance_common{
-	name = "Service Maintenance";
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint_cargo,
-/area/erida/crew_quarters/firing_range)
 "rGo" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -109964,6 +109948,11 @@
 /obj/effect/floor_decal/semiotic/storage,
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/warden)
+"rWI" = (
+/obj/structure/table/bar_special,
+/obj/item/deck/cards,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/eris/crew_quarters/bar)
 "rXZ" = (
 /mob/living/simple_animal/cat/fluff/bones,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -110029,6 +110018,14 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/engine_room)
+"sqX" = (
+/obj/structure/closet/secure_closet/personal/artist,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/third_section{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "sss" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -110141,6 +110138,14 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4;
+	tag = "icon-danger (EAST)"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
+"sCp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
 	tag = "icon-danger (EAST)"
@@ -110262,6 +110267,13 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
+"sQT" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/obj/landmark/join/start/artist,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "sRP" = (
 /obj/effect/floor_decal/semiotic/airlock,
 /turf/simulated/floor/tiled/white,
@@ -110333,14 +110345,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
-"tgP" = (
-/obj/item/contraband/poster/placed{
-	icon_state = "poster6";
-	pixel_x = -32;
-	tag = "icon-poster6"
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "tlV" = (
 /obj/structure/sign/semiotic/bulkhead{
 	pixel_x = 4;
@@ -110389,27 +110393,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
-"tvs" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/eris/crew_quarters/bar)
 "tzW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -110419,16 +110402,29 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck4central)
-"tAj" = (
-/obj/item/target/syndicate,
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/erida/crew_quarters/firing_range)
 "tCi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/oldtele)
+"tCZ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "tEu" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/lights/tubes,
@@ -110441,6 +110437,13 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/quartermaster/hangarsupply)
+"tHV" = (
+/obj/machinery/autolathe/artist_bench,
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "tMc" = (
 /obj/machinery/camera/network/engineering{
 	dir = 8
@@ -110452,11 +110455,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
-"tPD" = (
-/obj/structure/table/bar_special,
-/obj/item/deck/cards,
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/eris/crew_quarters/bar)
 "tPR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/steel,
@@ -110551,6 +110549,10 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/bioreactor)
+"ufA" = (
+/obj/item/gun/energy/laser/paladin,
+/turf/simulated/wall/r_wall,
+/area/eris/maintenance/section3deck5port)
 "uga" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
@@ -110694,6 +110696,14 @@
 /obj/spawner/pack/tech_loot/low_chance,
 /turf/simulated/floor/tiled/white/panels,
 /area/eris/rnd/scient)
+"uAg" = (
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/erida/crew_quarters/firing_range)
 "uAu" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -110817,14 +110827,10 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
-"uXe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
+"uXs" = (
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
 /area/eris/crew_quarters/artistoffice)
 "uXF" = (
 /obj/machinery/vending/cigarette,
@@ -110848,6 +110854,17 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/engine_room)
+"uZF" = (
+/obj/structure/closet/secure_closet/personal/artist,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
+"vbq" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "vbX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -110893,11 +110910,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8;
-	tag = "icon-danger (WEST)"
-	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/plating/under,
 /area/erida/crew_quarters/firing_range)
 "vhD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -110910,18 +110923,14 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
-"vhL" = (
-/obj/structure/closet/secure_closet/personal/artist,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/camera/network/third_section{
-	dir = 4
+"vjw" = (
+/obj/item/contraband/poster/placed{
+	icon_state = "poster6";
+	pixel_x = -32;
+	tag = "icon-poster6"
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/eris/crew_quarters/artistoffice)
-"vjw" = (
-/obj/machinery/vending/weapon_machine_practice,
-/turf/simulated/floor/tiled/dark/panels,
-/area/erida/crew_quarters/firing_range)
 "vkt" = (
 /obj/machinery/door/window/eastright{
 	name = "Research Desk";
@@ -111028,15 +111037,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section3)
 "vAE" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
+/obj/item/target/syndicate,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/erida/crew_quarters/firing_range)
 "vAO" = (
 /obj/structure/lattice,
@@ -111049,6 +111051,10 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
+"vDi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "vEQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -111157,6 +111163,21 @@
 /obj/machinery/neotheology/cruciformforge,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/neotheology/chapelritualroom)
+"vXJ" = (
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "North APC";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "vZa" = (
 /obj/machinery/door/blast/regular{
 	id = "scannerroom";
@@ -111353,6 +111374,18 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
+"wBV" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "wEJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -111367,11 +111400,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/long_range_scanner)
-"wGJ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating,
-/area/eris/crew_quarters/artistoffice)
 "wNc" = (
 /obj/machinery/gym/robustness,
 /turf/simulated/floor/reinforced,
@@ -111391,17 +111419,6 @@
 /obj/structure/sign/department/medbay,
 /turf/simulated/wall,
 /area/eris/medical/medbay/organs)
-"wUD" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4;
-	tag = "icon-danger (EAST)"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/erida/crew_quarters/firing_range)
 "wVo" = (
 /obj/structure/sign/semiotic/electronics{
 	pixel_x = -6;
@@ -111535,15 +111552,6 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/hangarsupply)
-"xxh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/landmark/join/start/artist,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "xzp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -111710,18 +111718,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
-"xYO" = (
-/obj/spawner/traps/low_chance,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck1central)
 "xZK" = (
 /obj/structure/multiz/stairs/enter{
 	dir = 4
@@ -123989,7 +123985,7 @@ aaa
 aaa
 alg
 alg
-gOt
+ufA
 alg
 alg
 asp
@@ -169855,11 +169851,11 @@ bBE
 cYb
 cjp
 aqa
-vhL
-xxh
-gpl
-tgP
-pcO
+sqX
+lRv
+ptr
+vjw
+uZF
 aqa
 cjp
 dXa
@@ -170057,11 +170053,11 @@ anJ
 cYO
 swy
 aqa
-fjw
-cxK
-emG
-cIg
+ewQ
+erC
 cQM
+bmS
+chZ
 aqa
 dMl
 clZ
@@ -170259,11 +170255,11 @@ anJ
 cWy
 apF
 aqa
-rxK
-rwv
-uXe
-cxK
-fue
+tHV
+sQT
+erI
+erC
+hdr
 aqa
 apF
 dTC
@@ -170461,11 +170457,11 @@ anJ
 cXK
 cjw
 aqa
-lND
-nON
+vXJ
 chV
-fzp
-hdr
+tCZ
+vDi
+hVL
 aqa
 dJD
 cmo
@@ -170660,17 +170656,17 @@ chE
 anJ
 cJV
 anJ
-kte
+kiQ
 bCz
 aqa
-wGJ
-wGJ
-gyW
-wGJ
-wGJ
+uXs
+uXs
+jcz
+uXs
+uXs
 aqa
 sXq
-iHQ
+jMD
 anJ
 apF
 anJ
@@ -170867,7 +170863,7 @@ apF
 cjM
 bTn
 bfC
-eNW
+nvS
 cjc
 clX
 cjM
@@ -171069,7 +171065,7 @@ apF
 apF
 cim
 cld
-tvs
+hAW
 cjd
 cpU
 clV
@@ -175706,8 +175702,8 @@ cgO
 ctq
 chh
 crA
-chZ
-chZ
+chJ
+chJ
 bAN
 ciC
 ciC
@@ -209856,7 +209852,7 @@ cjQ
 cjQ
 czL
 dXQ
-jwG
+foC
 lsO
 rPI
 cBC
@@ -210257,7 +210253,7 @@ ctE
 ewf
 cil
 cyV
-jwG
+foC
 czL
 dXQ
 cyV
@@ -211867,7 +211863,7 @@ buH
 evx
 dJV
 aqa
-muG
+hNH
 cJQ
 nXG
 apF
@@ -212079,7 +212075,7 @@ xIO
 ctE
 dXW
 kXR
-tPD
+rWI
 chY
 cpm
 cpm
@@ -288425,15 +288421,15 @@ dXi
 boN
 boN
 boS
-mAA
-rEg
-mAA
-nVL
-nVL
-ewQ
-ewQ
+ebc
+gUC
+ebc
+eqI
+eqI
+ouK
+ouK
 bsI
-ewQ
+ouK
 boS
 elC
 boS
@@ -288627,15 +288623,15 @@ dXi
 aNK
 cNH
 aCh
-mAA
-erX
+ebc
+wBV
 iGX
-chJ
-nVL
-ebc
-ebc
-ixz
-hML
+vbq
+eqI
+qmu
+qmu
+vfA
+jtR
 dXi
 bkF
 boS
@@ -288829,15 +288825,15 @@ dXi
 aNL
 cNH
 cNH
+uAg
+erX
 dgs
-vAE
-hiv
-nVL
-mAA
-mAA
-mAA
+eqI
+ebc
+ebc
+ebc
 nSC
-mAA
+ebc
 dXi
 bkF
 boS
@@ -289027,19 +289023,19 @@ alb
 alb
 aaa
 abF
-nVL
-mAA
-mAA
-mAA
-mAA
+eqI
+ebc
+ebc
+ebc
+ebc
 gaY
 jzc
 qOV
 mZv
 mZv
-wUD
+gwu
 fly
-jxB
+ero
 dXi
 bkF
 boS
@@ -289229,19 +289225,19 @@ abF
 abF
 aaa
 abF
-nVL
+eqI
 erw
 eWR
 erw
-eqI
-vAE
-hiv
-mBA
-oCA
-oCA
-oCA
+emG
+erX
+dgs
+nVL
+cIg
+cIg
+cIg
 lDx
-tAj
+vAE
 dXi
 bkF
 boS
@@ -289431,18 +289427,18 @@ abF
 abF
 aaa
 abF
-nVL
-erx
-erI
-erI
 eqI
-vAE
+erx
+dgs
+dgs
+emG
+erX
 uEA
-pzk
+rBg
 jir
 jir
 slc
-vfA
+cxK
 jir
 dXi
 bkF
@@ -289633,19 +289629,19 @@ abF
 abF
 aaa
 abF
-nVL
-vjw
-erI
+eqI
+hYW
+dgs
 erF
 enL
 exs
-hiv
-nVL
-ero
-mAA
-mAA
+dgs
+eqI
+oCA
+ebc
+ebc
 nSC
-mAA
+ebc
 dXi
 bkF
 boS
@@ -289835,19 +289831,19 @@ abF
 abF
 aaa
 abF
-nVL
-vjw
-erI
-erG
 eqI
-vAE
+hYW
+dgs
+erG
+emG
+erX
 xou
 rne
+sCp
+sCp
 lSz
-lSz
-nXt
 sBX
-jxB
+ero
 dXi
 bkF
 boN
@@ -290036,20 +290032,20 @@ abF
 abF
 abF
 aaa
-nVL
-nVL
-nVL
+eqI
+eqI
+eqI
 erz
 erH
-eqI
-vAE
-hiv
+emG
+erX
+dgs
 lgO
-oCA
-oCA
-oCA
+cIg
+cIg
+cIg
 lDx
-tAj
+vAE
 dXi
 bkF
 boN
@@ -290238,19 +290234,19 @@ abF
 abF
 abF
 aaa
-nVL
+eqI
 ezg
 ehJ
-erI
+dgs
 kLT
-mAA
-fWr
-hiv
+ebc
 pto
+hiv
+lxb
 jir
 jir
 slc
-vfA
+cxK
 jir
 dXi
 bkF
@@ -290440,20 +290436,20 @@ abF
 abF
 abF
 aaa
-nVL
+eqI
 erl
-nVL
+eqI
 ezm
-erI
-mAA
+dgs
+ebc
 enU
-mAA
-eqI
-eqI
-mAA
-mAA
+ebc
+emG
+emG
+ebc
+ebc
 nSC
-mAA
+ebc
 boS
 elC
 boS
@@ -290642,13 +290638,13 @@ enI
 enI
 abF
 aaa
-nVL
+eqI
 erm
-nVL
+eqI
 ezn
 ezq
-mAA
-xYO
+ebc
+muH
 bma
 bmU
 bqa
@@ -290844,13 +290840,13 @@ sJL
 enI
 abF
 aaa
-nVL
-nVL
-nVL
-erC
+eqI
+eqI
+eqI
+xou
 erK
+ebc
 mAA
-bmS
 cNH
 cNH
 bqn
@@ -291048,11 +291044,11 @@ aaa
 aaa
 dXi
 aCh
-mAA
-mAA
+ebc
+ebc
 ejK
+ebc
 mAA
-bmS
 cNH
 cNH
 bqn

--- a/maps/CEVEris/_CEV_Erida.dmm
+++ b/maps/CEVEris/_CEV_Erida.dmm
@@ -28443,9 +28443,16 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/lab)
 "bmS" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/eris/crew_quarters/artistoffice)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck1central)
 "bmT" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -49201,10 +49208,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
 "chJ" = (
-/obj/structure/table/rack/shelf,
-/obj/spawner/material/building,
-/turf/simulated/floor/tiled/steel,
-/area/eris/quartermaster/storage)
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "chK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -49278,16 +49287,21 @@
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/crew_quarters/janitor)
 "chV" = (
-/obj/structure/table/standard,
-/obj/machinery/recharger,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/item/stack/material/wood/random,
-/obj/item/stack/material/steel/random,
-/turf/simulated/floor/carpet/gaycarpet,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/crew_quarters/artistoffice)
 "chW" = (
 /obj/structure/cable/green{
@@ -49319,17 +49333,10 @@
 /turf/simulated/wall/r_wall,
 /area/eris/hallway/main/section3)
 "chZ" = (
-/obj/item/device/radio/intercom{
-	dir = 8;
-	pixel_x = 22
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
+/obj/structure/table/rack/shelf,
+/obj/spawner/material/building,
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/storage)
 "cia" = (
 /obj/structure/catwalk,
 /turf/simulated/open,
@@ -56085,21 +56092,8 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cxK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/effect/floor_decal/industrial/danger{
-	dir = 8;
-	tag = "icon-danger (WEST)"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/erida/crew_quarters/firing_range)
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "cxL" = (
 /obj/spawner/material/building,
 /obj/spawner/material/building,
@@ -60657,8 +60651,9 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/crew_quarters/janitor)
 "cIg" = (
-/turf/simulated/floor/tiled/dark/techfloor,
-/area/erida/crew_quarters/firing_range)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "cIh" = (
 /obj/item/modular_computer/console/preset/engineering/power,
 /turf/simulated/floor/tiled/dark/gray_perforated,
@@ -64111,14 +64106,16 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
 "cQM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/device/radio/intercom{
+	dir = 8;
+	pixel_x = 22
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
+/obj/machinery/light,
+/turf/simulated/floor/carpet/gaycarpet,
 /area/eris/crew_quarters/artistoffice)
 "cQN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
@@ -70882,7 +70879,12 @@
 /turf/simulated/floor/tiled/white/danger,
 /area/eris/rnd/xenobiology)
 "dgs" = (
-/turf/simulated/floor/tiled/dark/panels,
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techmaint_cargo,
 /area/erida/crew_quarters/firing_range)
 "dgt" = (
 /turf/simulated/wall/r_wall,
@@ -91681,7 +91683,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/anomalisoltwo)
 "ebc" = (
-/turf/simulated/wall,
+/turf/simulated/open,
 /area/erida/crew_quarters/firing_range)
 "ebd" = (
 /turf/simulated/floor/tiled/dark,
@@ -96638,10 +96640,15 @@
 /turf/simulated/open,
 /area/eris/maintenance/section4deck1central)
 "emG" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/erida/crew_quarters/firing_range)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "emH" = (
 /obj/structure/plasticflaps/mining,
 /turf/simulated/floor/plating/under,
@@ -98234,7 +98241,9 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/library)
 "eqI" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/erida/crew_quarters/firing_range)
 "eqJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -98549,10 +98558,9 @@
 /area/eris/medical/surgery)
 "ero" = (
 /obj/effect/floor_decal/industrial/danger{
-	dir = 4;
-	tag = "icon-danger (EAST)"
+	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/wall,
 /area/erida/crew_quarters/firing_range)
 "erp" = (
 /obj/machinery/light,
@@ -98631,7 +98639,7 @@
 /area/erida/crew_quarters/firing_range)
 "erx" = (
 /obj/machinery/camera/network/third_section,
-/turf/simulated/floor/tiled/dark/panels,
+/turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
 "ery" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -98649,7 +98657,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark/panels,
+/turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
 "erA" = (
 /obj/structure/table/standard,
@@ -98666,8 +98674,12 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
 "erC" = (
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/eris/crew_quarters/artistoffice)
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "erD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -98709,14 +98721,8 @@
 /turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
 "erI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/eris/crew_quarters/artistoffice)
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "erJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -98735,7 +98741,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/dark/panels,
+/turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
 "erL" = (
 /obj/machinery/door/firedoor,
@@ -98864,7 +98870,8 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
@@ -101187,12 +101194,12 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/section3starboard)
 "ewQ" = (
-/obj/item/modular_computer/console/preset/civilian/professional,
-/obj/machinery/light{
-	dir = 1
+/obj/structure/railing{
+	dir = 8;
+	tag = "icon-railing0 (WEST)"
 	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
+/turf/simulated/floor/plating/under,
+/area/erida/crew_quarters/firing_range)
 "ewR" = (
 /obj/structure/table/standard,
 /obj/item/clothing/mask/breath,
@@ -102338,7 +102345,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/turf/simulated/floor/tiled/dark/panels,
+/turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
 "ezn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -102374,7 +102381,7 @@
 	dir = 1;
 	pixel_y = -23
 	},
-/turf/simulated/floor/tiled/dark/panels,
+/turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
 "ezr" = (
 /obj/structure/disposalpipe/segment,
@@ -106017,6 +106024,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/space)
+"eNW" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/eris/crew_quarters/bar)
 "eOl" = (
 /obj/structure/catwalk,
 /obj/spawner/junk/low_chance,
@@ -106208,6 +106233,13 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/quartermaster/hangarsupply)
+"fjw" = (
+/obj/item/modular_computer/console/preset/civilian/professional,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "flx" = (
 /obj/structure/bed/chair/comfy/black{
 	dir = 4
@@ -106246,11 +106278,6 @@
 /obj/machinery/chemical_dispenser/soda,
 /turf/simulated/floor/wood,
 /area/eris/command/bridgebar)
-"foC" = (
-/obj/structure/table/bar_special,
-/obj/item/deck/cards,
-/turf/simulated/floor/tiled/steel/bar_light,
-/area/eris/crew_quarters/bar)
 "fpz" = (
 /obj/machinery/camera/network/fist_section{
 	dir = 8
@@ -106279,6 +106306,23 @@
 	},
 /turf/simulated/floor/tiled/white/panels,
 /area/eris/rnd/scient)
+"fue" = (
+/obj/structure/table/rack/shelf,
+/obj/item/device/synthesized_instrument/guitar/multi,
+/obj/item/device/synthesized_instrument/violin,
+/obj/item/device/synthesized_instrument/trumpet,
+/obj/item/device/synthesized_instrument/synthesizer,
+/obj/item/device/synthesized_instrument/guitar,
+/obj/item/clothing/mask/gas/monkeymask,
+/obj/item/clothing/suit/monkeysuit,
+/obj/item/clothing/head/ushanka,
+/obj/item/clothing/under/soviet,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
+"fzp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "fzU" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 4;
@@ -106419,6 +106463,18 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/quartermaster/hangarsupply)
+"fWr" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/third_section,
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "fWC" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -106523,6 +106579,12 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
+"gpl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
 "gsx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -106557,17 +106619,28 @@
 	},
 /turf/simulated/floor/grass,
 /area/eris/crew_quarters/hydroponics)
-"gwu" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4;
-	tag = "icon-danger (EAST)"
+"gyW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Artist Studio";
+	req_access = list(28)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/erida/crew_quarters/firing_range)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cargo,
+/area/eris/crew_quarters/artistoffice)
 "gzs" = (
 /obj/structure/flora/pottedplant/random,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -106619,6 +106692,10 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/eris/rnd/podbay)
+"gOt" = (
+/obj/item/gun/energy/laser/paladin,
+/turf/simulated/wall/r_wall,
+/area/eris/maintenance/section3deck5port)
 "gPD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -106659,19 +106736,6 @@
 	icon_state = "cargofloor1"
 	},
 /area/eris/hallway/side/eschangarb)
-"gUC" = (
-/obj/machinery/door/airlock/maintenance_common{
-	name = "Service Maintenance";
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/techmaint_cargo,
-/area/erida/crew_quarters/firing_range)
 "gXX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -106697,16 +106761,10 @@
 /turf/simulated/floor/wood,
 /area/eris/medical/psych)
 "hdr" = (
-/obj/structure/table/rack/shelf,
-/obj/item/device/synthesized_instrument/guitar/multi,
-/obj/item/device/synthesized_instrument/violin,
-/obj/item/device/synthesized_instrument/trumpet,
-/obj/item/device/synthesized_instrument/synthesizer,
-/obj/item/device/synthesized_instrument/guitar,
-/obj/item/clothing/mask/gas/monkeymask,
-/obj/item/clothing/suit/monkeysuit,
-/obj/item/clothing/head/ushanka,
-/obj/item/clothing/under/soviet,
+/obj/structure/closet/wardrobe/color/pink/artist,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/eris/crew_quarters/artistoffice)
 "hem" = (
@@ -106765,9 +106823,6 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/reception)
 "hiv" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
 "hlf" = (
@@ -106814,27 +106869,6 @@
 /obj/spawner/scrap/sparse/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5starboard)
-"hAW" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/eris/crew_quarters/bar)
 "hGN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -106899,22 +106933,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section1deck4central)
+"hML" = (
+/turf/simulated/floor/plating/under,
+/area/erida/crew_quarters/firing_range)
 "hNy" = (
 /obj/structure/closet/wall_mounted/firecloset{
 	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep/cryo)
-"hNH" = (
-/obj/structure/table/bar_special,
-/obj/structure/cyberplant{
-	pixel_x = 16;
-	pixel_y = -4;
-	possible_plants = list("emagged2-blue","emagged2-orange");
-	name = "\"Holo Dancer\""
-	},
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/eris/crew_quarters/bar)
 "hNQ" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -106952,13 +106979,6 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
-"hVL" = (
-/obj/structure/closet/wardrobe/color/pink/artist,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "hWY" = (
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/structure/railing/grey{
@@ -106966,10 +106986,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/hangarsupply)
-"hYW" = (
-/obj/machinery/vending/weapon_machine_practice,
-/turf/simulated/floor/tiled/dark/panels,
-/area/erida/crew_quarters/firing_range)
 "iaf" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -107101,6 +107117,18 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section2)
+"ixz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating/under,
+/area/erida/crew_quarters/firing_range)
 "iyV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -107133,6 +107161,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark/panels,
 /area/erida/crew_quarters/firing_range)
+"iHQ" = (
+/obj/effect/window_lwall_spawn/reinforced/polarized,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/bar)
 "iIc" = (
 /obj/effect/shuttle_landmark/merc/sec3east5,
 /turf/space,
@@ -107259,28 +107291,6 @@
 /obj/effect/decal/warning_stripes,
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
-"jcz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Artist Studio";
-	req_access = list(28)
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/eris/crew_quarters/artistoffice)
 "jgz" = (
 /obj/machinery/door/airlock{
 	name = "Male Showers"
@@ -107388,9 +107398,6 @@
 	},
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/engineering/post)
-"jtR" = (
-/turf/simulated/floor/plating/under,
-/area/erida/crew_quarters/firing_range)
 "juQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -107398,6 +107405,18 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
+"jwG" = (
+/obj/structure/table/bar_special,
+/obj/item/deck/cards,
+/turf/simulated/floor/tiled/steel/bar_light,
+/area/eris/crew_quarters/bar)
+"jxB" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4;
+	tag = "icon-danger (EAST)"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "jxG" = (
 /obj/effect/floor_decal/industrial/danger{
 	dir = 8;
@@ -107506,10 +107525,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
-"jMD" = (
-/obj/effect/window_lwall_spawn/reinforced/polarized,
-/turf/simulated/floor/plating,
-/area/eris/crew_quarters/bar)
 "jRe" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -107601,11 +107616,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck2port)
-"kiQ" = (
-/obj/effect/window_lwall_spawn/reinforced/polarized,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/eris/crew_quarters/bar)
 "klx" = (
 /obj/machinery/holomap{
 	dir = 1;
@@ -107644,6 +107654,11 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/range)
+"kte" = (
+/obj/effect/window_lwall_spawn/reinforced/polarized,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/bar)
 "kvo" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -107938,11 +107953,6 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
-"lxb" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/steel/cargo,
-/area/erida/crew_quarters/firing_range)
 "lxN" = (
 /obj/structure/lattice,
 /turf/simulated/wall/r_wall,
@@ -108063,6 +108073,21 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck1central)
+"lND" = (
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "North APC";
+	pixel_y = 28
+	},
+/obj/structure/cable/green{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "lOA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/cargo,
@@ -108085,15 +108110,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
-"lRv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/landmark/join/start/artist,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "lRz" = (
 /obj/structure/noticeboard{
 	pixel_x = -32
@@ -108126,9 +108142,6 @@
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
 	tag = "icon-danger (EAST)"
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
@@ -108285,18 +108298,16 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck5port)
-"muH" = (
-/obj/spawner/traps/low_chance,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"muG" = (
+/obj/structure/table/bar_special,
+/obj/structure/cyberplant{
+	pixel_x = 16;
+	pixel_y = -4;
+	possible_plants = list("emagged2-blue","emagged2-orange");
+	name = "\"Holo Dancer\""
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/eris/crew_quarters/bar)
 "mvb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -108331,16 +108342,15 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/maintenance/junk)
 "mAA" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck1central)
+/turf/simulated/wall,
+/area/erida/crew_quarters/firing_range)
+"mBA" = (
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/item/clothing/ears/earmuffs,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/erida/crew_quarters/firing_range)
 "mBD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -108603,24 +108613,6 @@
 	},
 /turf/space,
 /area/space)
-"nvS" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/bar_dance,
-/area/eris/crew_quarters/bar)
 "nAL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -108728,6 +108720,18 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
+"nON" = (
+/obj/structure/table/standard,
+/obj/machinery/recharger,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/item/stack/material/wood/random,
+/obj/item/stack/material/steel/random,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "nQt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -108782,11 +108786,7 @@
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/security/checkpoint/medical)
 "nVL" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/item/clothing/ears/earmuffs,
-/turf/simulated/floor/tiled/steel/cargo,
+/turf/simulated/wall/r_wall,
 /area/erida/crew_quarters/firing_range)
 "nWN" = (
 /obj/structure/table/marble,
@@ -108799,6 +108799,17 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/side/eschangarb)
+"nXt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4;
+	tag = "icon-danger (EAST)"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "nXG" = (
 /obj/structure/bed/chair/custom/bar_special{
 	dir = 1
@@ -108967,13 +108978,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
-"ouK" = (
-/obj/structure/railing{
-	dir = 8;
-	tag = "icon-railing0 (WEST)"
-	},
-/turf/simulated/floor/plating/under,
-/area/erida/crew_quarters/firing_range)
 "ouQ" = (
 /obj/structure/table/rack,
 /obj/item/tool/hammer/dumbbell{
@@ -109100,10 +109104,7 @@
 /turf/simulated/floor/hull,
 /area/space)
 "oCA" = (
-/obj/effect/floor_decal/industrial/danger{
-	dir = 1
-	},
-/turf/simulated/wall,
+/turf/simulated/floor/tiled/dark/techfloor,
 /area/erida/crew_quarters/firing_range)
 "oGr" = (
 /obj/machinery/door/airlock/multi_tile/glass{
@@ -109214,6 +109215,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
+"pcO" = (
+/obj/structure/closet/secure_closet/personal/artist,
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "pij" = (
 /obj/machinery/requests_console{
 	dir = 1;
@@ -109257,23 +109262,10 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
 "pto" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/camera/network/third_section,
-/turf/simulated/floor/tiled/techmaint,
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/erida/crew_quarters/firing_range)
-"ptr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/eris/crew_quarters/artistoffice)
 "ptL" = (
 /obj/structure/closet/self_pacification,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -109304,6 +109296,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
+"pzk" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/space,
+/area/erida/crew_quarters/firing_range)
 "pEk" = (
 /obj/machinery/door/airlock{
 	name = "Male Restroom"
@@ -109445,9 +109442,6 @@
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/engineering/atmos/storage)
-"qmu" = (
-/turf/simulated/open,
-/area/erida/crew_quarters/firing_range)
 "qmN" = (
 /obj/structure/bed/chair/shuttle,
 /obj/spawner/scrap,
@@ -109773,6 +109767,20 @@
 /obj/structure/cable/green,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/fitness)
+"rwv" = (
+/obj/structure/bed/chair/office/light{
+	dir = 4
+	},
+/obj/landmark/join/start/artist,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/crew_quarters/artistoffice)
+"rxK" = (
+/obj/machinery/autolathe/artist_bench,
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "rze" = (
 /obj/structure/table/rack,
 /obj/spawner/lowkeyrandom,
@@ -109792,11 +109800,6 @@
 "rBd" = (
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics/garden)
-"rBg" = (
-/obj/effect/window_lwall_spawn/smartspawn,
-/obj/machinery/door/firedoor,
-/turf/space,
-/area/erida/crew_quarters/firing_range)
 "rBy" = (
 /obj/machinery/atmospherics/pipe/zpipe/down,
 /obj/structure/railing{
@@ -109815,6 +109818,19 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/eris/engineering/atmos/storage)
+"rEg" = (
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/erida/crew_quarters/firing_range)
 "rGo" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -109948,11 +109964,6 @@
 /obj/effect/floor_decal/semiotic/storage,
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/warden)
-"rWI" = (
-/obj/structure/table/bar_special,
-/obj/item/deck/cards,
-/turf/simulated/floor/tiled/steel/bar_flat,
-/area/eris/crew_quarters/bar)
 "rXZ" = (
 /mob/living/simple_animal/cat/fluff/bones,
 /turf/simulated/floor/carpet/sblucarpet,
@@ -110018,14 +110029,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/engine_room)
-"sqX" = (
-/obj/structure/closet/secure_closet/personal/artist,
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/camera/network/third_section{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "sss" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -110138,14 +110141,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/floor_decal/industrial/danger{
-	dir = 4;
-	tag = "icon-danger (EAST)"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/erida/crew_quarters/firing_range)
-"sCp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/danger{
 	dir = 4;
 	tag = "icon-danger (EAST)"
@@ -110267,13 +110262,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep_male/toilet_male)
-"sQT" = (
-/obj/structure/bed/chair/office/light{
-	dir = 4
-	},
-/obj/landmark/join/start/artist,
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/eris/crew_quarters/artistoffice)
 "sRP" = (
 /obj/effect/floor_decal/semiotic/airlock,
 /turf/simulated/floor/tiled/white,
@@ -110345,6 +110333,14 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"tgP" = (
+/obj/item/contraband/poster/placed{
+	icon_state = "poster6";
+	pixel_x = -32;
+	tag = "icon-poster6"
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "tlV" = (
 /obj/structure/sign/semiotic/bulkhead{
 	pixel_x = 4;
@@ -110393,6 +110389,27 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/chapel)
+"tvs" = (
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/eris/crew_quarters/bar)
 "tzW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -110402,29 +110419,16 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck4central)
+"tAj" = (
+/obj/item/target/syndicate,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/erida/crew_quarters/firing_range)
 "tCi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/oldtele)
-"tCZ" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/techfloor_grid,
-/area/eris/crew_quarters/artistoffice)
 "tEu" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/lights/tubes,
@@ -110437,13 +110441,6 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/quartermaster/hangarsupply)
-"tHV" = (
-/obj/machinery/autolathe/artist_bench,
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "tMc" = (
 /obj/machinery/camera/network/engineering{
 	dir = 8
@@ -110455,6 +110452,11 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"tPD" = (
+/obj/structure/table/bar_special,
+/obj/item/deck/cards,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/eris/crew_quarters/bar)
 "tPR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/steel,
@@ -110549,10 +110551,6 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/bioreactor)
-"ufA" = (
-/obj/item/gun/energy/laser/paladin,
-/turf/simulated/wall/r_wall,
-/area/eris/maintenance/section3deck5port)
 "uga" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8;
@@ -110696,14 +110694,6 @@
 /obj/spawner/pack/tech_loot/low_chance,
 /turf/simulated/floor/tiled/white/panels,
 /area/eris/rnd/scient)
-"uAg" = (
-/obj/machinery/door/airlock/maintenance_common{
-	name = "Service Maintenance";
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/techmaint_cargo,
-/area/erida/crew_quarters/firing_range)
 "uAu" = (
 /obj/effect/window_lwall_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -110827,10 +110817,14 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
-"uXs" = (
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating,
+"uXe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/crew_quarters/artistoffice)
 "uXF" = (
 /obj/machinery/vending/cigarette,
@@ -110854,17 +110848,6 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/engine_room)
-"uZF" = (
-/obj/structure/closet/secure_closet/personal/artist,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
-"vbq" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/erida/crew_quarters/firing_range)
 "vbX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -110910,7 +110893,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating/under,
+/obj/effect/floor_decal/industrial/danger{
+	dir = 8;
+	tag = "icon-danger (WEST)"
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
 "vhD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -110923,14 +110910,18 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
-"vjw" = (
-/obj/item/contraband/poster/placed{
-	icon_state = "poster6";
-	pixel_x = -32;
-	tag = "icon-poster6"
+"vhL" = (
+/obj/structure/closet/secure_closet/personal/artist,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/camera/network/third_section{
+	dir = 4
 	},
 /turf/simulated/floor/carpet/gaycarpet,
 /area/eris/crew_quarters/artistoffice)
+"vjw" = (
+/obj/machinery/vending/weapon_machine_practice,
+/turf/simulated/floor/tiled/dark/panels,
+/area/erida/crew_quarters/firing_range)
 "vkt" = (
 /obj/machinery/door/window/eastright{
 	name = "Research Desk";
@@ -111037,8 +111028,15 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/hallway/main/section3)
 "vAE" = (
-/obj/item/target/syndicate,
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/erida/crew_quarters/firing_range)
 "vAO" = (
 /obj/structure/lattice,
@@ -111051,10 +111049,6 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/crew_quarters/fitness)
-"vDi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "vEQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -111163,21 +111157,6 @@
 /obj/machinery/neotheology/cruciformforge,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/neotheology/chapelritualroom)
-"vXJ" = (
-/obj/structure/table/standard,
-/obj/item/paper_bin,
-/obj/item/pen/blue,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/carpet/gaycarpet,
-/area/eris/crew_quarters/artistoffice)
 "vZa" = (
 /obj/machinery/door/blast/regular{
 	id = "scannerroom";
@@ -111374,18 +111353,6 @@
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
-"wBV" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/erida/crew_quarters/firing_range)
 "wEJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -111400,6 +111367,11 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/long_range_scanner)
+"wGJ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/artistoffice)
 "wNc" = (
 /obj/machinery/gym/robustness,
 /turf/simulated/floor/reinforced,
@@ -111419,6 +111391,17 @@
 /obj/structure/sign/department/medbay,
 /turf/simulated/wall,
 /area/eris/medical/medbay/organs)
+"wUD" = (
+/obj/effect/floor_decal/industrial/danger{
+	dir = 4;
+	tag = "icon-danger (EAST)"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/erida/crew_quarters/firing_range)
 "wVo" = (
 /obj/structure/sign/semiotic/electronics{
 	pixel_x = -6;
@@ -111552,6 +111535,15 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/hangarsupply)
+"xxh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/landmark/join/start/artist,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/carpet/gaycarpet,
+/area/eris/crew_quarters/artistoffice)
 "xzp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -111718,6 +111710,18 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"xYO" = (
+/obj/spawner/traps/low_chance,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck1central)
 "xZK" = (
 /obj/structure/multiz/stairs/enter{
 	dir = 4
@@ -123985,7 +123989,7 @@ aaa
 aaa
 alg
 alg
-ufA
+gOt
 alg
 alg
 asp
@@ -169851,11 +169855,11 @@ bBE
 cYb
 cjp
 aqa
-sqX
-lRv
-ptr
-vjw
-uZF
+vhL
+xxh
+gpl
+tgP
+pcO
 aqa
 cjp
 dXa
@@ -170053,11 +170057,11 @@ anJ
 cYO
 swy
 aqa
-ewQ
-erC
+fjw
+cxK
+emG
+cIg
 cQM
-bmS
-chZ
 aqa
 dMl
 clZ
@@ -170255,11 +170259,11 @@ anJ
 cWy
 apF
 aqa
-tHV
-sQT
-erI
-erC
-hdr
+rxK
+rwv
+uXe
+cxK
+fue
 aqa
 apF
 dTC
@@ -170457,11 +170461,11 @@ anJ
 cXK
 cjw
 aqa
-vXJ
+lND
+nON
 chV
-tCZ
-vDi
-hVL
+fzp
+hdr
 aqa
 dJD
 cmo
@@ -170656,17 +170660,17 @@ chE
 anJ
 cJV
 anJ
-kiQ
+kte
 bCz
 aqa
-uXs
-uXs
-jcz
-uXs
-uXs
+wGJ
+wGJ
+gyW
+wGJ
+wGJ
 aqa
 sXq
-jMD
+iHQ
 anJ
 apF
 anJ
@@ -170863,7 +170867,7 @@ apF
 cjM
 bTn
 bfC
-nvS
+eNW
 cjc
 clX
 cjM
@@ -171065,7 +171069,7 @@ apF
 apF
 cim
 cld
-hAW
+tvs
 cjd
 cpU
 clV
@@ -175702,8 +175706,8 @@ cgO
 ctq
 chh
 crA
-chJ
-chJ
+chZ
+chZ
 bAN
 ciC
 ciC
@@ -209852,7 +209856,7 @@ cjQ
 cjQ
 czL
 dXQ
-foC
+jwG
 lsO
 rPI
 cBC
@@ -210253,7 +210257,7 @@ ctE
 ewf
 cil
 cyV
-foC
+jwG
 czL
 dXQ
 cyV
@@ -211863,7 +211867,7 @@ buH
 evx
 dJV
 aqa
-hNH
+muG
 cJQ
 nXG
 apF
@@ -212075,7 +212079,7 @@ xIO
 ctE
 dXW
 kXR
-rWI
+tPD
 chY
 cpm
 cpm
@@ -288421,15 +288425,15 @@ dXi
 boN
 boN
 boS
-ebc
-gUC
-ebc
-eqI
-eqI
-ouK
-ouK
+mAA
+rEg
+mAA
+nVL
+nVL
+ewQ
+ewQ
 bsI
-ouK
+ewQ
 boS
 elC
 boS
@@ -288623,15 +288627,15 @@ dXi
 aNK
 cNH
 aCh
-ebc
-wBV
+mAA
+erX
 iGX
-vbq
-eqI
-qmu
-qmu
-vfA
-jtR
+chJ
+nVL
+ebc
+ebc
+ixz
+hML
 dXi
 bkF
 boS
@@ -288825,15 +288829,15 @@ dXi
 aNL
 cNH
 cNH
-uAg
-erX
 dgs
-eqI
-ebc
-ebc
-ebc
+vAE
+hiv
+nVL
+mAA
+mAA
+mAA
 nSC
-ebc
+mAA
 dXi
 bkF
 boS
@@ -289023,19 +289027,19 @@ alb
 alb
 aaa
 abF
-eqI
-ebc
-ebc
-ebc
-ebc
+nVL
+mAA
+mAA
+mAA
+mAA
 gaY
 jzc
 qOV
 mZv
 mZv
-gwu
+wUD
 fly
-ero
+jxB
 dXi
 bkF
 boS
@@ -289225,19 +289229,19 @@ abF
 abF
 aaa
 abF
-eqI
+nVL
 erw
 eWR
 erw
-emG
-erX
-dgs
-nVL
-cIg
-cIg
-cIg
-lDx
+eqI
 vAE
+hiv
+mBA
+oCA
+oCA
+oCA
+lDx
+tAj
 dXi
 bkF
 boS
@@ -289427,18 +289431,18 @@ abF
 abF
 aaa
 abF
-eqI
+nVL
 erx
-dgs
-dgs
-emG
-erX
+erI
+erI
+eqI
+vAE
 uEA
-rBg
+pzk
 jir
 jir
 slc
-cxK
+vfA
 jir
 dXi
 bkF
@@ -289629,19 +289633,19 @@ abF
 abF
 aaa
 abF
-eqI
-hYW
-dgs
+nVL
+vjw
+erI
 erF
 enL
 exs
-dgs
-eqI
-oCA
-ebc
-ebc
+hiv
+nVL
+ero
+mAA
+mAA
 nSC
-ebc
+mAA
 dXi
 bkF
 boS
@@ -289831,19 +289835,19 @@ abF
 abF
 aaa
 abF
-eqI
-hYW
-dgs
+nVL
+vjw
+erI
 erG
-emG
-erX
+eqI
+vAE
 xou
 rne
-sCp
-sCp
 lSz
+lSz
+nXt
 sBX
-ero
+jxB
 dXi
 bkF
 boN
@@ -290032,20 +290036,20 @@ abF
 abF
 abF
 aaa
-eqI
-eqI
-eqI
+nVL
+nVL
+nVL
 erz
 erH
-emG
-erX
-dgs
-lgO
-cIg
-cIg
-cIg
-lDx
+eqI
 vAE
+hiv
+lgO
+oCA
+oCA
+oCA
+lDx
+tAj
 dXi
 bkF
 boN
@@ -290234,19 +290238,19 @@ abF
 abF
 abF
 aaa
-eqI
+nVL
 ezg
 ehJ
-dgs
+erI
 kLT
-ebc
-pto
+mAA
+fWr
 hiv
-lxb
+pto
 jir
 jir
 slc
-cxK
+vfA
 jir
 dXi
 bkF
@@ -290436,20 +290440,20 @@ abF
 abF
 abF
 aaa
-eqI
+nVL
 erl
-eqI
+nVL
 ezm
-dgs
-ebc
+erI
+mAA
 enU
-ebc
-emG
-emG
-ebc
-ebc
+mAA
+eqI
+eqI
+mAA
+mAA
 nSC
-ebc
+mAA
 boS
 elC
 boS
@@ -290638,13 +290642,13 @@ enI
 enI
 abF
 aaa
-eqI
+nVL
 erm
-eqI
+nVL
 ezn
 ezq
-ebc
-muH
+mAA
+xYO
 bma
 bmU
 bqa
@@ -290840,13 +290844,13 @@ sJL
 enI
 abF
 aaa
-eqI
-eqI
-eqI
-xou
+nVL
+nVL
+nVL
+erC
 erK
-ebc
 mAA
+bmS
 cNH
 cNH
 bqn
@@ -291044,11 +291048,11 @@ aaa
 aaa
 dXi
 aCh
-ebc
-ebc
-ejK
-ebc
 mAA
+mAA
+ejK
+mAA
+bmS
 cNH
 cNH
 bqn


### PR DESCRIPTION
## About The Pull Request

- Renovated Public Shooting Range
  - Added practice round vending machine
  - Added Practice Rifles, batteries, and chargers
  - Removed "Clown Office" to give public accessway
- Moved Artist Office out of FTU area into Club
  - Original location has been turned into storage closet for now

## Why It's Good For The Game

My alterations to the firing range make it more accessible to the public and tie it into the structure of the ship more cohesively, as well as adding objects to make the area usable.

The Artist has been placed under the "Club" department, so it needs to be moved to be with their new department (Also I'm pretty sure the artist wasn't able to actually get to the old location because of access changes

## Testing

![image](https://github.com/user-attachments/assets/e62f07b2-8ece-4e7b-8632-888eab5246cb)
![image](https://github.com/user-attachments/assets/1faaefd9-e048-4839-bf47-fda684fc3a1e)


## Changelog
:cl:

fix: Fixed the Firing Range
fix: Moved the Artist Office from the Union to the Club

/:cl:


