### PR TITLE
Updates _compiler_options.dm to include a warning when you try to compile on 515.

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -66,6 +66,14 @@
 #error Please consider downgrading to 514.1575 or lower.
 #endif
 
+// // // BEGIN ECLIPSE EDITS // // //
+// Addresses a known issue when trying to compile on 515.
+#if DM_VERSION == 515
+#warn BYOND version 515 has a known issue where datums with no parent cannot call a New() proc.
+#warn If you encounter compiler failures, consider downgrading your dev environment to 514. A known good version is 514.1589.
+#endif
+// // // END ECLIPSE EDITS // // //
+
 //Additional code for the above flags.
 #ifdef TESTING
 #warn compiling in TESTING mode. testing() debug messages will be visible.

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -69,7 +69,7 @@
 // // // BEGIN ECLIPSE EDITS // // //
 // Addresses a known issue when trying to compile on 515.
 #if DM_VERSION == 515
-#warn BYOND version 515 has a known issue where datums with no parent cannot call a New() proc.
+#warn BYOND version 515 has a known issue where datums with no parent cannot call a New() proc under certain circumstances.
 #warn If you encounter compiler failures, consider downgrading your dev environment to 514. A known good version is 514.1589.
 #endif
 // // // END ECLIPSE EDITS // // //


### PR DESCRIPTION
## About The Pull Request

Adds a compiler warning for when a player attempts to compile things for Byond version 515. For more information, see #1809.

**This PR contains no player-visible changes.**

## Why It's Good For The Game

Less confusion for when people try to help out is always good.

## Testing

Tested on 515.1643, compiler warning appeared before the errors did (though if TGUI is compiled, it gets slightly lost.)
![image](https://github.com/user-attachments/assets/0ee1480b-f796-4e03-b38e-b71872f08a2c)
![image](https://github.com/user-attachments/assets/29d221cf-0bca-469b-bba4-7b651e827840)

Tested on 514.1589, compiler warning was not present.
![image](https://github.com/user-attachments/assets/fdb9e0ff-be01-4d2a-9742-f40285e08954)
![image](https://github.com/user-attachments/assets/2e9e794c-af5e-4724-88c0-99d5bcec8b47)



## Changelog
:cl:
server: Minor tweaks to compiler settings. No player-visible changes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
