### PR TITLE
Changelog compiler tweaks

### DIFF
--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -68,7 +68,8 @@ else:
 write_cl['delete-after'] = True
 
 with open(Path.cwd().joinpath("tools/changelog/tags.yml")) as file:
-    tags = yaml.safe_load(file)
+    safe_yaml = YAML(typ='safe', pure='True')
+    tags = safe_yaml.load(file)
 
 write_cl['changes'] = []
 


### PR DESCRIPTION
## About The Pull Request

The subroutine it was trying to call is deprecated and removed, and thus throws errors. 

```py
Traceback (most recent call last):
  File "/home/runner/work/NEV-Northern-Light/NEV-Northern-Light/tools/changelog/generate_cl.py", line 71, in <module>
    tags = yaml.safe_load(file)
  File "/opt/hostedtoolcache/Python/3.13.5/x64/lib/python3.13/site-packages/ruamel/yaml/main.py", line 1108, in safe_load
    error_deprecation('safe_load', 'load', arg="typ='safe', pure=True")
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.13.5/x64/lib/python3.13/site-packages/ruamel/yaml/main.py", line 1042, in error_deprecation
    raise AttributeError(s, name=None)
AttributeError: 
"safe_load()" has been removed, use

  yaml = YAML(typ='safe', pure=True)
  yaml.load(...)

instead of file "/home/runner/work/NEV-Northern-Light/NEV-Northern-Light/tools/changelog/generate_cl.py", line 71

    tags = yaml.safe_load(file)
```

I used `safe_yaml` in lieu of `yaml` for disambiguation, but otherwise this mirrors the implementation that Eris uses. (Yes, I checked.)

## Why It's Good For The Game

Compiled changelogs help players see what's new.

## Testing
### This is untested.
As this is a GitHub workflow controller, I cannot test it without merging it; what it does after the merge *is* the test.

## Changelog
:cl: EvilJackCarver
fix: Updated changelog compiler to remove a deprecated function call.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
