### PR TITLE
Changelog Fixes, Part 2

### DIFF
--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -68,7 +68,7 @@ else:
 write_cl['delete-after'] = True
 
 with open(Path.cwd().joinpath("tools/changelog/tags.yml")) as file:
-    safe_yaml = YAML(typ='safe', pure='True')
+    safe_yaml = yaml.YAML(typ='safe', pure='True')
     tags = safe_yaml.load(file)
 
 write_cl['changes'] = []


### PR DESCRIPTION
## About The Pull Request

Continuation of #1828. I forgot to call the package the YAML define was in, so it failed with a "you idiot this define isn't defined" error.

See main pull request for details.

## Testing

As with 1828, untestable without running the workflow which is triggered by a pull request being merged.

## Changelog
:cl: EvilJackCarver
fix: Updated changelog compiler to remove a deprecated function call.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally Frepresent how a player might be affected by the changes rather than a summary of the PR's contents. -->
