### PR TITLE
Updates workflows for futureproofing

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -10,7 +10,7 @@ jobs:
   run_linters:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Run Linters
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     concurrency:
       group: run_linters-${{ github.ref }}
       cancel-in-progress: true
@@ -56,7 +56,7 @@ jobs:
   compile_all_maps:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Compile Maps
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     concurrency:
       group: compile_all_maps-${{ github.ref }}
       cancel-in-progress: true
@@ -76,7 +76,7 @@ jobs:
   run_all_tests:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Integration Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     services:
       mysql:
         image: mysql:latest
@@ -127,7 +127,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && always()"
     needs: [run_all_tests]
     name: Compare Screenshot Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Setup directory

--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -10,7 +10,7 @@ jobs:
   run_linters:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Run Linters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     concurrency:
       group: run_linters-${{ github.ref }}
       cancel-in-progress: true
@@ -56,7 +56,7 @@ jobs:
   compile_all_maps:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Compile Maps
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     concurrency:
       group: compile_all_maps-${{ github.ref }}
       cancel-in-progress: true
@@ -76,7 +76,7 @@ jobs:
   run_all_tests:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:latest
@@ -127,7 +127,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && always()"
     needs: [run_all_tests]
     name: Compare Screenshot Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Setup directory

--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   compile:
     name: "Compile changelogs"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Check for CHANGELOG_ENABLER secret and pass true to output if it exists to be checked by later steps"
         id: value_holder

--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   triage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: mschilde/auto-label-merge-conflicts@2e8fcc76c6430272ec8bb64fb74ec1592156aa6a
         with:

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: write  # for JamesIves/github-pages-deploy-action to push changes in repo
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency: gen-docs
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/show_screenshot_test_results.yml
+++ b/.github/workflows/show_screenshot_test_results.yml
@@ -13,7 +13,7 @@ jobs:
   show_screenshot_test_results:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Show Screenshot Test Results
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Check for ARTIFACTS_FILE_HOUSE_KEY"
         id: secrets_set


### PR DESCRIPTION
## About The Pull Request

Ubuntu 20.04 LTS has been removed from service by GitHub. This updates us to use `ubuntu-latest` on all workflows (including the one which currently uses 22.04) for futureproofing purposes. 

(If we need to fall back to a specific version later, it's easy enough to do so.)

## Why It's Good For The Game

So we don't lose more workflows because of GitHub deprecating operating systems

## Testing

This is a change to a GitHub workflow, and thus cannot be tested without merging.

## Changelog

Changelog intentionally left blank.
